### PR TITLE
Fix(store): add a file open option to write without remaining data

### DIFF
--- a/pkg/lobster/util/util.go
+++ b/pkg/lobster/util/util.go
@@ -189,7 +189,7 @@ func DiskInfo(path string) (cap uint64, used uint64, err error) {
 }
 
 func WriteFile(path, fileName string, data []byte) error {
-	f, err := os.OpenFile(fmt.Sprintf("%s/%s", path, fileName), os.O_WRONLY|os.O_CREATE, 0600)
+	f, err := os.OpenFile(fmt.Sprintf("%s/%s", path, fileName), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Related: https://github.com/naver/lobster/issues/12

Truncate writable file when opened
- label file
- check point file