### PR TITLE
Fix(exporter): fix parser to also parse the timestamp in a single log line

### DIFF
--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -35,6 +35,7 @@ import (
 	"github.com/naver/lobster/pkg/lobster/sink/order"
 	"github.com/naver/lobster/pkg/lobster/store"
 	"github.com/naver/lobster/pkg/lobster/util"
+	"github.com/pkg/errors"
 
 	sinkV1 "github.com/naver/lobster/pkg/operator/api/v1"
 )
@@ -248,7 +249,12 @@ func parseStart(data []byte) (time.Time, error) {
 func parseEnd(data []byte) (time.Time, error) {
 	index := bytes.LastIndexAny(data[:len(data)-2], "\n")
 	if index < 0 {
-		return time.Time{}, fmt.Errorf("failed to parse end")
+		t, err := logline.ParseTimestamp(string(data))
+		if err != nil {
+			return time.Time{}, errors.Wrap(err, "failed to parse end")
+		}
+
+		return t, nil
 	}
 
 	return logline.ParseTimestamp(string(data[index+1:]))


### PR DESCRIPTION
Related: https://github.com/naver/lobster/issues/11

The current implementation uses newline characters to identify the last line in the extracted logs. 
This should be updated to ensure that timestamps are also checked when no newline is ahead. 