### PR TITLE
Add panic and pprof

### DIFF
--- a/pkg/lobster/distributor/distributor.go
+++ b/pkg/lobster/distributor/distributor.go
@@ -89,7 +89,7 @@ func (d *Distributor) Run(stopChan chan struct{}) {
 				}
 
 				if len(podMap) == 0 {
-					continue
+					panic("no pods found")
 				}
 
 				d.updateLabelsInChunks(podMap)
@@ -101,7 +101,7 @@ func (d *Distributor) Run(stopChan chan struct{}) {
 				}
 
 				if len(logfiles) == 0 {
-					continue
+					panic("no log files found")
 				}
 
 				fileMap := d.extractFileMap(logfiles, *conf.FileInspectMaxStale)

--- a/pkg/lobster/loader/loader.go
+++ b/pkg/lobster/loader/loader.go
@@ -68,10 +68,7 @@ func LoadLogfiles(path string, labelFunc LabelFunc, parseFunc ParseFunc) ([]mode
 			}
 		}
 
-		labels, err := labelFunc(pf.Name())
-		if err != nil && !os.IsNotExist(err) {
-			glog.Error(err)
-		}
+		labels, _ := labelFunc(pf.Name())
 
 		for i := 0; i < len(logfilesOfPod); i++ {
 			logfilesOfPod[i].Labels = labels

--- a/pkg/lobster/server/router.go
+++ b/pkg/lobster/server/router.go
@@ -20,6 +20,8 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+
+	_ "net/http/pprof"
 )
 
 func Router() *mux.Router {
@@ -27,6 +29,7 @@ func Router() *mux.Router {
 	router.Path("/health").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	})
+	router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 
 	return router
 }

--- a/pkg/operator/server/server.go
+++ b/pkg/operator/server/server.go
@@ -34,6 +34,8 @@ import (
 
 	"github.com/naver/lobster/pkg/operator/server/controller"
 	"github.com/naver/lobster/pkg/operator/server/handler"
+
+	_ "net/http/pprof"
 )
 
 //	@title			Lobster Operator APIs document
@@ -78,6 +80,7 @@ func setupRouter(sinkClient client.Client, logger logr.Logger) *mux.Router {
 	router.Path("/health").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte("ok"))
 	})
+	router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 	router.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("/static/"))))
 	router.PathPrefix("/swagger/").Handler(httpSwagger.Handler(
 		httpSwagger.URL("/web/static/docs/swagger.json"),


### PR DESCRIPTION
- Add panic to restart the process if no pods or files are found
  - Occasionally, a pod list may fail to be retrieved from kubelet for certain reasons, and restarting the process resolves this issue
  - To handle this, induce a restart by triggering a panic when no pods or files are found
- Add `pprof` for debugging purposes and remove unnecessary logs