### PR TITLE
Fix(query): Fix the label matcher to avoid using `contains` when distinguishing each label for chunk

### DIFF
--- a/pkg/lobster/model/labels.go
+++ b/pkg/lobster/model/labels.go
@@ -40,6 +40,16 @@ func (l Labels) Pairs() []string {
 	return kvs
 }
 
+func (l Labels) PairKeyMap() map[string]bool {
+	pairKeyMap := map[string]bool{}
+
+	for k, v := range l {
+		pairKeyMap[fmt.Sprintf("%s%s%s", k, LabelKeyValueDelimiter, v)] = true
+	}
+
+	return pairKeyMap
+}
+
 func (l Labels) String() string {
 	return strings.Join(l.Pairs(), LabelsDelimiter)
 }

--- a/pkg/lobster/querier/matcher_test.go
+++ b/pkg/lobster/querier/matcher_test.go
@@ -32,7 +32,7 @@ var (
 )
 
 func init() {
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 20; i++ {
 		suffix := fmt.Sprintf("-%d", i)
 		chunk, _ := model.NewChunk(model.LogFile{
 			Labels:    map[string]string{"label": "label" + suffix},
@@ -186,9 +186,9 @@ func TestMatchMultipleLabels(t *testing.T) {
 		matchedLabelString := matched.Labels.String()
 
 		for _, labelString := range expectedLabelStrings {
-			if strings.Contains(matchedLabelString, labelString) {
+			if matchedLabelString == labelString {
 				hasProperLabel = true
-				break
+				break // escape this to check 'or condition'
 			}
 		}
 


### PR DESCRIPTION
Invalid chunks are sometimes returned with label requests.
This occurs because the labels are partially not matched exactly, but partially.
With this fix, the labels will be matched exactly.

For example, a query parameter with `labelA=1` could return chunks that contain `labelA=12`.