### PR TITLE
fix the log tailer to ensure it drains all remaining logs without waiting

### DIFF
--- a/pkg/lobster/tailer/tailer.go
+++ b/pkg/lobster/tailer/tailer.go
@@ -33,7 +33,6 @@ import (
 const (
 	statusRunning status = 1
 	statusIdle    status = 2
-	drainWait            = time.Millisecond
 )
 
 type status int
@@ -177,8 +176,6 @@ func (t *Tailer) doStop() {
 
 func (t *Tailer) drain() {
 	t.tail.Kill(nil)
-
-	time.Sleep(drainWait)
 
 	select {
 	case <-t.LogChan:

--- a/pkg/lobster/tailer/tailer.go
+++ b/pkg/lobster/tailer/tailer.go
@@ -186,7 +186,7 @@ func (t *Tailer) drain() {
 		close(t.LogChan)
 	}
 
-	for t.tail.IsSending {
+	for t.tail.IsTailing {
 		select {
 		case <-t.tail.Lines:
 		default:


### PR DESCRIPTION
In the previous version, the tailer was designed to perform a drain operation on the channel receiver for remaining logs, ensuring the tailer could terminate gracefully. 
To account for cases where logs might arrive after the drain attempt.

When disk delays occur, logs may still arrive after the drain operation. 
This usually happens with larger log byte sizes, causing delays. 

To address this, the tailer has been updated to ensure it can drain all remaining logs, even under such delayed conditions.
