### PR TITLE
Fix timestamps of write buffer

### DIFF
--- a/pkg/lobster/store/buffer.go
+++ b/pkg/lobster/store/buffer.go
@@ -56,12 +56,17 @@ func (w *writeBuffer) write(ts time.Time, input string) {
 
 	w.lines = w.lines + 1
 	w.fileOffset = w.fileOffset + int64(len(input))
+
+	w.start = w.histories[0].ts
+	w.end = w.histories[len(w.histories)-1].ts
 }
 
 func (w writeBuffer) inspect(ts time.Time) (int, int, bool) {
-	minTs := ts.Add(-maxAge)
-	historyIdx := len(w.histories) - 1
-	dataIdx := len(w.data)
+	var (
+		minTs      = ts.Add(-maxAge)
+		historyIdx = len(w.histories) - 1
+		dataIdx    = len(w.data)
+	)
 
 	if len(w.histories) == 0 || w.histories[len(w.histories)-1].ts.Before(ts) {
 		return 0, 0, false


### PR DESCRIPTION
When logs are ingested out of chronological order, the buffer performs reordering to ensure proper sequencing. 
During this process, the buffer's start and end timestamps are also updated accordingly.