### PR TITLE
add an option to encode file name

### DIFF
--- a/pkg/lobster/sink/exporter/bucket/basic.go
+++ b/pkg/lobster/sink/exporter/bucket/basic.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -90,7 +91,13 @@ func (b BasicBucket) Dir(chunk model.Chunk, date time.Time) string {
 }
 
 func (b BasicBucket) FileName(start, end time.Time) string {
-	return fmt.Sprintf("%s_%s.log", start.Format(layoutFileName), end.Format(layoutFileName))
+	fileName := fmt.Sprintf("%s_%s.log", start.Format(layoutFileName), end.Format(layoutFileName))
+
+	if b.Order.LogExportRule.ShouldEncodeFileName {
+		return strings.ReplaceAll(fileName, "+", "%2B")
+	}
+
+	return fileName
 }
 
 func (b BasicBucket) Validate() error {

--- a/pkg/lobster/sink/exporter/bucket/s3.go
+++ b/pkg/lobster/sink/exporter/bucket/s3.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -75,8 +76,14 @@ func (s S3Bucket) Dir(chunk model.Chunk, date time.Time) string {
 		dirPath)
 }
 
-func (s S3Bucket) FileName(start, end time.Time) string {
-	return fmt.Sprintf("%s_%s.log", start.Format(layoutFileName), end.Format(layoutFileName))
+func (b S3Bucket) FileName(start, end time.Time) string {
+	fileName := fmt.Sprintf("%s_%s.log", start.Format(layoutFileName), end.Format(layoutFileName))
+
+	if b.Order.LogExportRule.ShouldEncodeFileName {
+		return strings.ReplaceAll(fileName, "+", "%2B")
+	}
+
+	return fileName
 }
 
 func (s S3Bucket) Validate() error {

--- a/pkg/operator/api/v1/logExportRule.go
+++ b/pkg/operator/api/v1/logExportRule.go
@@ -41,6 +41,8 @@ type LogExportRule struct {
 	Filter Filter `json:"filter,omitempty"`
 	// Interval to export logs
 	Interval metav1.Duration `json:"interval,omitempty" swaggertype:"string" example:"time duration(e.g. 1m)"`
+	// Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted
+	ShouldEncodeFileName bool `json:"shouldEncodeFileName,omitempty"`
 }
 
 func (r LogExportRule) Validate() error {


### PR DESCRIPTION
Provide a file name encoding option to resolve `+` character issues in certain storage environments.