### PR TITLE
fix to ensure the tailer is cleaned on termination

### DIFF
--- a/pkg/lobster/tailer/tailer.go
+++ b/pkg/lobster/tailer/tailer.go
@@ -177,6 +177,7 @@ func (t *Tailer) doStop() {
 
 func (t *Tailer) drain() {
 	t.tail.Kill(nil)
+	t.tail.Cleanup()
 
 	select {
 	case <-t.LogChan:


### PR DESCRIPTION
There is a deadlock issue with inotify watch add/remove. 
Referencing https://github.com/hpcloud/tail/issues/75, `CleanUp()` is added to allow exiting from the blocking channel that waits for events.

```
goroutine 258 [select, 3640 minutes]:
gopkg.in/fsnotify/fsnotify%2ev1.(*Watcher).readEvents(0xc001922000)
	/go/pkg/mod/gopkg.in/fsnotify/fsnotify.v1@v1.4.7/inotify.go:284 +0x8e7
created by gopkg.in/fsnotify/fsnotify%2ev1.NewWatcher in goroutine 257
	/go/pkg/mod/gopkg.in/fsnotify/fsnotify.v1@v1.4.7/inotify.go:59 +0x186

goroutine 195 [chan send, 3640 minutes]:
github.com/naver/lobster/pkg/lobster/tailer/tail/watch.remove(0xc00172ae88)
	/workspace/pkg/lobster/tailer/tail/watch/inotify_tracker.go:131 +0x1e7
github.com/naver/lobster/pkg/lobster/tailer/tail/watch.RemoveWatch(...)
	/workspace/pkg/lobster/tailer/tail/watch/inotify_tracker.go:87
github.com/naver/lobster/pkg/lobster/tailer/tail/watch.(*InotifyFileWatcher).ChangeEvents.func1()
	/workspace/pkg/lobster/tailer/tail/watch/inotify.go:91 +0x3b8
created by github.com/naver/lobster/pkg/lobster/tailer/tail/watch.(*InotifyFileWatcher).ChangeEvents in goroutine 30
	/workspace/pkg/lobster/tailer/tail/watch/inotify.go:75 +0x1aa


goroutine 28749456 [chan send, 3174 minutes]:
github.com/naver/lobster/pkg/lobster/tailer/tail/watch.watch(0xc002b1e240)
	/workspace/pkg/lobster/tailer/tail/watch/inotify_tracker.go:81 +0x85
github.com/naver/lobster/pkg/lobster/tailer/tail/watch.Watch(...)
	/workspace/pkg/lobster/tailer/tail/watch/inotify_tracker.go:62
github.com/naver/lobster/pkg/lobster/tailer/tail/watch.(*InotifyFileWatcher).ChangeEvents(0xc001ff2000, 0xc002606208, 0x13f0)
	/workspace/pkg/lobster/tailer/tail/watch/inotify.go:67 +0x75
github.com/naver/lobster/pkg/lobster/tailer/tail.(*Tail).waitForChanges(0xc002606180)
	/workspace/pkg/lobster/tailer/tail/tail.go:356 +0x74
github.com/naver/lobster/pkg/lobster/tailer/tail.(*Tail).tailFileSync(0xc002606180)
	/workspace/pkg/lobster/tailer/tail/tail.go:323 +0x616
created by github.com/naver/lobster/pkg/lobster/tailer/tail.TailFile in goroutine 28748879
	/workspace/pkg/lobster/tailer/tail/tail.go:138 +0x2e5

goroutine 257 [select, 3640 minutes]:
github.com/naver/lobster/pkg/lobster/tailer/tail/watch.(*InotifyTracker).sendEvent(0xc001916080, {{0xc004a8bb00?, 0x7e?}, 0x0?})
	/workspace/pkg/lobster/tailer/tail/watch/inotify_tracker.go:219 +0x174
github.com/naver/lobster/pkg/lobster/tailer/tail/watch.(*InotifyTracker).run(0xc001916080)
	/workspace/pkg/lobster/tailer/tail/watch/inotify_tracker.go:247 +0x332
created by github.com/naver/lobster/pkg/lobster/tailer/tail/watch.init.func1 in goroutine 30
	/workspace/pkg/lobster/tailer/tail/watch/inotify_tracker.go:54 +0x14e

goroutine 258 [select, 3640 minutes]:
gopkg.in/fsnotify/fsnotify%2ev1.(*Watcher).readEvents(0xc001922000)
	/go/pkg/mod/gopkg.in/fsnotify/fsnotify.v1@v1.4.7/inotify.go:284 +0x8e7
created by gopkg.in/fsnotify/fsnotify%2ev1.NewWatcher in goroutine 257
	/go/pkg/mod/gopkg.in/fsnotify/fsnotify.v1@v1.4.7/inotify.go:59 +0x186
```