### PR TITLE
Support out of timestamp order

### DIFF
--- a/docs/design/notes.md
+++ b/docs/design/notes.md
@@ -8,7 +8,8 @@
   - There may be a discrepancy between the timestamp in the log and the time of logging, resulting in inconsistencies such as querying logs outside their intended time period
 - Measures taken
   - Logs are collected and sorted in chronological order within a specified time period before being stored
-    Logs are collected and sorted before retrieval
+    - This operation is performed only within the `store.leakyBucketInterval (default 1s)`
+    - Logs with a timestamp difference greater than this interval are written directly without reordering
   - This issue can occur if logs arrive in reverse order during the collection and storage cycle
 
 ### Explanation of each file log rotation method

--- a/pkg/loggen/stub.go
+++ b/pkg/loggen/stub.go
@@ -43,7 +43,7 @@ func generateLogs(logger *log.Logger, conf Config, stopChan chan struct{}, logFo
 			str.WriteString(fmt.Sprintf("%d", i))
 		}
 
-		logSequences = append(logSequences, logFormatter(str.String()))
+		logSequences = append(logSequences, str.String())
 	}
 
 	for {
@@ -52,7 +52,7 @@ func generateLogs(logger *log.Logger, conf Config, stopChan chan struct{}, logFo
 			index = (index + 1) % 10
 
 			for i := 0; i < *conf.LogLines; i++ {
-				logger.Print(logSequences[index])
+				logger.Print(logFormatter(logSequences[index]))
 			}
 
 		case <-stopChan:


### PR DESCRIPTION
Reordering is supported until the buffer is flushed.
For already written blocks, changing their time order is difficult, so in such cases, logs are written as-is.
However, they are supported to be included in query responses.