### PR TITLE
fix log export field

### DIFF
--- a/deploy/templates/operator/manifests/crd.yaml
+++ b/deploy/templates/operator/manifests/crd.yaml
@@ -59,6 +59,11 @@ spec:
                           description: Root directory to store logs within external
                             storage
                           type: string
+                        shouldEncodeFileName:
+                          description: Provide an option to convert '+' to '%2B' to
+                            address issues in certain web environments where '+' is
+                            misinterpreted
+                          type: boolean
                         timeLayoutOfSubDirectory:
                           description: An option(default `2006-01`) that sets the
                             name of the sub-directory following `{Root path}` to a
@@ -214,6 +219,11 @@ spec:
                         secretKey:
                           description: S3 bucket secret key
                           type: string
+                        shouldEncodeFileName:
+                          description: Provide an option to convert '+' to '%2B' to
+                            address issues in certain web environments where '+' is
+                            misinterpreted
+                          type: boolean
                         tags:
                           additionalProperties:
                             type: string
@@ -225,10 +235,6 @@ spec:
                             time-based layout
                           type: string
                       type: object
-                    shouldEncodeFileName:
-                      description: Provide an option to convert '+' to '%2B' to address
-                        issues in certain web environments where '+' is misinterpreted
-                      type: boolean
                   type: object
                 type: array
               logMetricRules:

--- a/pkg/docs/operator/docs.go
+++ b/pkg/docs/operator/docs.go
@@ -219,6 +219,10 @@ const docTemplate = `{
                     "description": "Root directory to store logs within external storage",
                     "type": "string"
                 },
+                "shouldEncodeFileName": {
+                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
+                    "type": "boolean"
+                },
                 "timeLayoutOfSubDirectory": {
                     "description": "An option(default ` + "`" + `2006-01` + "`" + `) that sets the name of the sub-directory following ` + "`" + `{Root path}` + "`" + ` to a time-based layout",
                     "type": "string",
@@ -379,10 +383,6 @@ const docTemplate = `{
                             "$ref": "#/definitions/v1.S3Bucket"
                         }
                     ]
-                },
-                "shouldEncodeFileName": {
-                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
-                    "type": "boolean"
                 }
             }
         },
@@ -433,6 +433,10 @@ const docTemplate = `{
                 "secretKey": {
                     "description": "S3 bucket secret key",
                     "type": "string"
+                },
+                "shouldEncodeFileName": {
+                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
+                    "type": "boolean"
                 },
                 "tags": {
                     "description": "Tags for objects to be stored",

--- a/pkg/docs/operator/swagger.json
+++ b/pkg/docs/operator/swagger.json
@@ -211,6 +211,10 @@
                     "description": "Root directory to store logs within external storage",
                     "type": "string"
                 },
+                "shouldEncodeFileName": {
+                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
+                    "type": "boolean"
+                },
                 "timeLayoutOfSubDirectory": {
                     "description": "An option(default `2006-01`) that sets the name of the sub-directory following `{Root path}` to a time-based layout",
                     "type": "string",
@@ -371,10 +375,6 @@
                             "$ref": "#/definitions/v1.S3Bucket"
                         }
                     ]
-                },
-                "shouldEncodeFileName": {
-                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
-                    "type": "boolean"
                 }
             }
         },
@@ -425,6 +425,10 @@
                 "secretKey": {
                     "description": "S3 bucket secret key",
                     "type": "string"
+                },
+                "shouldEncodeFileName": {
+                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
+                    "type": "boolean"
                 },
                 "tags": {
                     "description": "Tags for objects to be stored",

--- a/pkg/docs/operator/swagger.yaml
+++ b/pkg/docs/operator/swagger.yaml
@@ -7,6 +7,10 @@ definitions:
       rootPath:
         description: Root directory to store logs within external storage
         type: string
+      shouldEncodeFileName:
+        description: Provide an option to convert '+' to '%2B' to address issues in
+          certain web environments where '+' is misinterpreted
+        type: boolean
       timeLayoutOfSubDirectory:
         default: 2006-01
         description: An option(default `2006-01`) that sets the name of the sub-directory
@@ -113,10 +117,6 @@ definitions:
         allOf:
         - $ref: '#/definitions/v1.S3Bucket'
         description: Settings required to export logs to S3 bucket
-      shouldEncodeFileName:
-        description: Provide an option to convert '+' to '%2B' to address issues in
-          certain web environments where '+' is misinterpreted
-        type: boolean
     type: object
   v1.LogMetricRule:
     properties:
@@ -151,6 +151,10 @@ definitions:
       secretKey:
         description: S3 bucket secret key
         type: string
+      shouldEncodeFileName:
+        description: Provide an option to convert '+' to '%2B' to address issues in
+          certain web environments where '+' is misinterpreted
+        type: boolean
       tags:
         allOf:
         - $ref: '#/definitions/v1.Tags'

--- a/pkg/lobster/sink/exporter/uploader/basic.go
+++ b/pkg/lobster/sink/exporter/uploader/basic.go
@@ -91,7 +91,7 @@ func (b BasicUploader) Dir(chunk model.Chunk, date time.Time) string {
 func (b BasicUploader) FileName(start, end time.Time) string {
 	fileName := fmt.Sprintf("%s_%s.log", start.Format(layoutFileName), end.Format(layoutFileName))
 
-	if b.Order.LogExportRule.ShouldEncodeFileName {
+	if b.Order.LogExportRule.BasicBucket.ShouldEncodeFileName {
 		return strings.ReplaceAll(fileName, "+", "%2B")
 	}
 

--- a/pkg/lobster/sink/exporter/uploader/kafka.go
+++ b/pkg/lobster/sink/exporter/uploader/kafka.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	defaultClientId = "lobster"
-	produceTimeout  = 5 * time.Second
+	dialTimeout     = time.Second
 )
 
 type TokenProvider struct {
@@ -106,6 +106,7 @@ func newConfig(kafka *v1.Kafka) (*sarama.Config, error) {
 
 	config.ClientID = defaultClientId
 	config.Producer.Return.Successes = true
+	config.Net.DialTimeout = dialTimeout
 
 	if kafka.TLS.Enable {
 		config.Net.TLS.Enable = true

--- a/pkg/lobster/sink/exporter/uploader/s3.go
+++ b/pkg/lobster/sink/exporter/uploader/s3.go
@@ -77,7 +77,7 @@ func (s S3Uploader) Dir(chunk model.Chunk, date time.Time) string {
 func (b S3Uploader) FileName(start, end time.Time) string {
 	fileName := fmt.Sprintf("%s_%s.log", start.Format(layoutFileName), end.Format(layoutFileName))
 
-	if b.Order.LogExportRule.ShouldEncodeFileName {
+	if b.Order.LogExportRule.S3Bucket.ShouldEncodeFileName {
 		return strings.ReplaceAll(fileName, "+", "%2B")
 	}
 

--- a/pkg/operator/api/v1/basicBucket.go
+++ b/pkg/operator/api/v1/basicBucket.go
@@ -27,6 +27,8 @@ type BasicBucket struct {
 	RootPath string `json:"rootPath,omitempty"`
 	// An option(default `2006-01`) that sets the name of the sub-directory following `{Root path}` to a time-based layout
 	TimeLayoutOfSubDirectory string `json:"timeLayoutOfSubDirectory,omitempty" default:"2006-01"`
+	// Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted
+	ShouldEncodeFileName bool `json:"shouldEncodeFileName,omitempty"`
 }
 
 func (b BasicBucket) Validate() error {

--- a/pkg/operator/api/v1/logExportRule.go
+++ b/pkg/operator/api/v1/logExportRule.go
@@ -43,8 +43,6 @@ type LogExportRule struct {
 	Filter Filter `json:"filter,omitempty"`
 	// Interval to export logs
 	Interval metav1.Duration `json:"interval,omitempty" swaggertype:"string" example:"time duration(e.g. 1m)"`
-	// Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted
-	ShouldEncodeFileName bool `json:"shouldEncodeFileName,omitempty"`
 }
 
 func (r LogExportRule) Validate() error {

--- a/pkg/operator/api/v1/logExportRule.go
+++ b/pkg/operator/api/v1/logExportRule.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	MinBucketInterval = time.Minute
+	MinBucketInterval = 15 * time.Second
 	MaxBucketInterval = time.Hour
 )
 
@@ -51,7 +51,7 @@ func (r LogExportRule) Validate() error {
 	}
 
 	if r.Interval.Seconds() < MinBucketInterval.Seconds() {
-		return fmt.Errorf("`interval` should be greater than or equal to %dm", int(MinBucketInterval.Minutes()))
+		return fmt.Errorf("`interval` should be greater than or equal to %dm", int(MinBucketInterval.Seconds()))
 	}
 
 	if MaxBucketInterval.Seconds() < r.Interval.Seconds() {

--- a/pkg/operator/api/v1/s3Bucket.go
+++ b/pkg/operator/api/v1/s3Bucket.go
@@ -53,6 +53,8 @@ type S3Bucket struct {
 	SecretKey string `json:"secretKey,omitempty"`
 	// Tags for objects to be stored
 	Tags Tags `json:"tags,omitempty"`
+	// Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted
+	ShouldEncodeFileName bool `json:"shouldEncodeFileName,omitempty"`
 }
 
 func (s S3Bucket) Validate() error {

--- a/web/static/docs/operator/swagger.json
+++ b/web/static/docs/operator/swagger.json
@@ -211,6 +211,10 @@
                     "description": "Root directory to store logs within external storage",
                     "type": "string"
                 },
+                "shouldEncodeFileName": {
+                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
+                    "type": "boolean"
+                },
                 "timeLayoutOfSubDirectory": {
                     "description": "An option(default `2006-01`) that sets the name of the sub-directory following `{Root path}` to a time-based layout",
                     "type": "string",
@@ -371,10 +375,6 @@
                             "$ref": "#/definitions/v1.S3Bucket"
                         }
                     ]
-                },
-                "shouldEncodeFileName": {
-                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
-                    "type": "boolean"
                 }
             }
         },
@@ -425,6 +425,10 @@
                 "secretKey": {
                     "description": "S3 bucket secret key",
                     "type": "string"
+                },
+                "shouldEncodeFileName": {
+                    "description": "Provide an option to convert '+' to '%2B' to address issues in certain web environments where '+' is misinterpreted",
+                    "type": "boolean"
                 },
                 "tags": {
                     "description": "Tags for objects to be stored",


### PR DESCRIPTION
Move the `shouldEncodeFileName` field from the common log export rule field to a type-specific field for better clarity and organization.