### PR TITLE
add a pod list cache to continue tailing logs even if the API server or kubelet fails

### DIFF
--- a/pkg/lobster/distributor/distributor.go
+++ b/pkg/lobster/distributor/distributor.go
@@ -82,11 +82,7 @@ func (d *Distributor) Run(stopChan chan struct{}) {
 		for {
 			select {
 			case <-inspectTicker.C:
-				podMap, err := d.client.GetPods()
-				if err != nil {
-					glog.Error(err)
-					continue
-				}
+				podMap := d.client.GetPods()
 
 				if len(podMap) == 0 {
 					panic("no pods found")

--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -76,12 +76,7 @@ func (e *LogExporter) Run(stopChan chan struct{}) {
 			now := time.Now()
 			current := now.Truncate(time.Second)
 			newOrders := map[string]order.Order{}
-
-			podMap, err := e.client.GetPods()
-			if err != nil {
-				glog.Error(err)
-				continue
-			}
+			podMap := e.client.GetPods()
 
 			if len(podMap) == 0 {
 				panic("no pods found")


### PR DESCRIPTION
Previously, if there was an issue with the API server or kubelet and the pod list retrieval failed, the tailer was not added.

In this version, even if pod list retrieval fails, the previously cached pod list is utilized.
This ensures that a closed tailer in an idle state can also be tracked in the next loop using the cached pod list.