### PR TITLE
Fix path template to construct the directory properly 

### DIFF
--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -223,7 +223,7 @@ func (e *LogExporter) getAndExportLogs(uploader uploader.Uploader, request query
 		}
 
 		fileName := uploader.FileName(pStart, pEnd)
-		dir := uploader.Dir(chunk, start)
+		dir := uploader.Dir(chunk, pStart)
 
 		if err := uploader.Upload(data, dir, fileName); err != nil {
 			return time.Time{}, 0, err

--- a/pkg/lobster/sink/exporter/uploader/basic.go
+++ b/pkg/lobster/sink/exporter/uploader/basic.go
@@ -101,6 +101,8 @@ func (b BasicUploader) Validate() v1.ValidationErrors {
 }
 
 func (b BasicUploader) Upload(data []byte, dir, fileName string) error {
+	var start = time.Now()
+
 	u, err := url.Parse(b.Order.LogExportRule.BasicBucket.Destination)
 	if err != nil {
 		return err
@@ -120,10 +122,13 @@ func (b BasicUploader) Upload(data []byte, dir, fileName string) error {
 		return err
 	}
 
+	defer func() {
+		glog.Infof("[basic][took %fs] upload %d bytes to %s", time.Since(start).Seconds(), len(data), u.String())
+	}()
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	glog.Infof("[basic] upload %d bytes to %s", len(data), u.String())
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body.Bytes()))
 	if err != nil {
 		return err

--- a/pkg/lobster/sink/exporter/uploader/kafka.go
+++ b/pkg/lobster/sink/exporter/uploader/kafka.go
@@ -75,6 +75,12 @@ func (k KafkaUploader) Validate() v1.ValidationErrors {
 }
 
 func (k KafkaUploader) Upload(data []byte, dir, fileName string) error {
+	var start = time.Now()
+
+	defer func() {
+		glog.Infof("[kafka][took %fs] upload %d bytes to topic `%s` for %s", time.Since(start).Seconds(), len(data), k.Order.LogExportRule.Kafka.Topic, k.Order.Request.String())
+	}()
+
 	config, err := k.newConfig(k.Order.LogExportRule.Kafka)
 	if err != nil {
 		return err
@@ -89,8 +95,6 @@ func (k KafkaUploader) Upload(data []byte, dir, fileName string) error {
 	if err := producer.SendMessages(newMessages(k.Order.LogExportRule.Kafka, data)); err != nil {
 		return err
 	}
-
-	glog.Infof("[kafka] upload %d bytes to topic `%s` for %s", len(data), k.Order.LogExportRule.Kafka.Topic, k.Order.Request.String())
 
 	return nil
 }

--- a/pkg/lobster/sink/exporter/uploader/s3.go
+++ b/pkg/lobster/sink/exporter/uploader/s3.go
@@ -87,6 +87,8 @@ func (s S3Uploader) Validate() v1.ValidationErrors {
 }
 
 func (s S3Uploader) Upload(data []byte, dir, fileName string) error {
+	var start = time.Now()
+
 	s3Session, err := session.NewSession(&aws.Config{
 		Endpoint:         aws.String(s.Order.LogExportRule.S3Bucket.Destination),
 		Credentials:      credentials.NewStaticCredentials(s.Order.LogExportRule.S3Bucket.AccessKey, s.Order.LogExportRule.S3Bucket.SecretKey, ""),
@@ -112,12 +114,13 @@ func (s S3Uploader) Upload(data []byte, dir, fileName string) error {
 		input.Tagging = aws.String(s.Order.LogExportRule.S3Bucket.Tags.String())
 	}
 
-	result, err := s3manager.NewUploader(s3Session).Upload(input)
-	if err != nil {
+	defer func() {
+		glog.Infof("[s3][took %fs] upload %d bytes to %s(%s) for %s", time.Since(start).Seconds(), len(data), *input.Bucket, *input.Key, s.Order.Request.String())
+	}()
+
+	if _, err := s3manager.NewUploader(s3Session).Upload(input); err != nil {
 		return errors.Wrap(err, "failed to upload file")
 	}
-
-	glog.Infof("[s3] upload %d bytes to %s", len(data), result.Location)
 
 	return nil
 }

--- a/pkg/operator/api/v1/template/template_test.go
+++ b/pkg/operator/api/v1/template/template_test.go
@@ -74,3 +74,31 @@ func TestInvalidPath(t *testing.T) {
 		}
 	}
 }
+
+func TestGeneratePathWithCachedTemplates(t *testing.T) {
+	templateStr := "/{{TimeLayout \"20060102\"}}/{{.SinkName}}"
+	dates := map[string]time.Time{
+		"/20250106/2025-01-06T00:00:00Z": time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC),
+		"/20250107/2025-01-07T00:00:00Z": time.Date(2025, 1, 7, 0, 0, 0, 0, time.UTC),
+		"/20250108/2025-01-08T00:00:00Z": time.Date(2025, 1, 8, 0, 0, 0, 0, time.UTC),
+	}
+
+	elem := PathElement{}
+
+	for expected, date := range dates {
+		elem.TimeInput = date                     // time func
+		elem.SinkName = date.Format(time.RFC3339) // string field
+
+		path, err := GeneratePath(templateStr, elem)
+		if err != nil {
+			t.Errorf("failed to generating path for template %q: %v\n", templateStr, err)
+			return
+		}
+		if path != expected {
+			t.Errorf("invalid result: %s vs %s", path, expected)
+			return
+		}
+
+		t.Logf("template: %q\npath: %s", templateStr, path)
+	}
+}


### PR DESCRIPTION
- The cached `template` for log export does not update when new data is input
  Therefore, fix it to allow reuse of the cached template properly
- Fix the directory's start time to reference the log's start time directly