### PR TITLE
fix locale of block path

### DIFF
--- a/pkg/lobster/model/block.go
+++ b/pkg/lobster/model/block.go
@@ -81,9 +81,9 @@ func (b Block) EndTime() time.Time {
 
 func (b Block) FileName() string {
 	return fmt.Sprintf("%s%s%s%s%d%s%d.log",
-		b.StartedAt.Format(time.RFC3339Nano),
+		b.StartedAt.Local().Format(time.RFC3339Nano),
 		blockNameDelimiter,
-		b.EndedAt.Format(time.RFC3339Nano),
+		b.EndedAt.Local().Format(time.RFC3339Nano),
 		blockNameDelimiter,
 		b.Line,
 		blockNameDelimiter,

--- a/pkg/lobster/sink/exporter/counter/counter.go
+++ b/pkg/lobster/sink/exporter/counter/counter.go
@@ -43,9 +43,10 @@ func NewCounter(dataPath string) Counter {
 
 func (c Counter) Produce(bytes int, exportTime time.Time, interval time.Duration, logTime time.Time) Receipt {
 	return Receipt{
-		ExportBytes: bytes,
-		ExportTime:  exportTime,
-		LogTime:     logTime,
+		ExportBytes:    bytes,
+		ExportTime:     exportTime,
+		ExportInterval: interval,
+		LogTime:        logTime,
 	}
 }
 
@@ -92,7 +93,7 @@ func (c Counter) Clean(current time.Time) {
 			return nil
 		}
 
-		glog.Infof("delete stale receipts %s", string(k))
+		glog.Infof("delete stale receipts %s : %v", string(k), receipt)
 		targets = append(targets, k)
 
 		return nil

--- a/pkg/lobster/sink/exporter/counter/receipt.go
+++ b/pkg/lobster/sink/exporter/counter/receipt.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-const liveFactor = 2
+const liveFactor = 3
 
 type Receipt struct {
 	ExportBytes    int

--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -227,7 +227,9 @@ func (e *LogExporter) export(current time.Time, uploader uploader.Uploader, orde
 		logTs = current
 	}
 
-	receipt.Update(total, current, interval, logTs)
+	if total > 0 {
+		receipt.Update(total, current, interval, logTs)
+	}
 
 	return receipt.ExportBytes, err
 }


### PR DESCRIPTION
If a large amount of logs are produced, the log export should look up old blocks to retrieve the file logs. 
However, an invalid block path name can prevent finding the proper blocks.