### PR TITLE
Fix receipt management

### DIFF
--- a/pkg/lobster/sink/exporter/counter/counter.go
+++ b/pkg/lobster/sink/exporter/counter/counter.go
@@ -93,7 +93,7 @@ func (c Counter) Clean(current time.Time) {
 			return nil
 		}
 
-		glog.Infof("delete stale receipts %s", string(k))
+		glog.Infof("delete stale receipts %s : %v", string(k), receipt)
 		targets = append(targets, k)
 
 		return nil

--- a/pkg/lobster/sink/exporter/counter/counter.go
+++ b/pkg/lobster/sink/exporter/counter/counter.go
@@ -43,9 +43,10 @@ func NewCounter(dataPath string) Counter {
 
 func (c Counter) Produce(bytes int, exportTime time.Time, interval time.Duration, logTime time.Time) Receipt {
 	return Receipt{
-		ExportBytes: bytes,
-		ExportTime:  exportTime,
-		LogTime:     logTime,
+		ExportBytes:    bytes,
+		ExportTime:     exportTime,
+		ExportInterval: interval,
+		LogTime:        logTime,
 	}
 }
 

--- a/pkg/lobster/sink/exporter/counter/receipt.go
+++ b/pkg/lobster/sink/exporter/counter/receipt.go
@@ -20,7 +20,7 @@ import (
 	"time"
 )
 
-const liveFactor = 2
+const liveFactor = 3
 
 type Receipt struct {
 	ExportBytes    int

--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -227,7 +227,9 @@ func (e *LogExporter) export(current time.Time, uploader uploader.Uploader, orde
 		logTs = current
 	}
 
-	receipt.Update(total, current, interval, logTs)
+	if total > 0 {
+		receipt.Update(total, current, interval, logTs)
+	}
 
 	return receipt.ExportBytes, err
 }


### PR DESCRIPTION
- Include the time of the failure and retry for each export interval, based on the live factor, then clean up
- Update the receipt only when exported log bytes are observed(>0)

```
// as-is
// - Update the receipt regardless of failure or log volume
// - Attempt starting from 15:32:49
// to-be
// - If there are no previously exported logs, retry from that point in time
// - Attempt starting from 15:32:45
// - 15:32:45 to 15:32:54: The range gradually increases by the interval set by the user.
I0321 15:32:55.686572       1 basic.go:126] [basic][took 0.012869s] ... 2025-03-21T15:32:45+09:00_2025-03-21T15:32:54+09:00.log
E0321 15:32:55.686817       1 exporter.go:139] Post "http://testxxx/2025-03-21T15:32:45+09:00_2025-03-21T15:32:54+09:00.log": dial tcp: lookup testxxx on ...: no such host : ...

// to-be: 15:32:45 to 15:32:59
I0321 15:33:00.700746       1 basic.go:126] [basic][took 0.009139s] ... 2025-03-21T15:32:45+09:00_2025-03-21T15:32:59+09:00.log
E0321 15:33:00.701005       1 exporter.go:139] Post "http://testxxx/2025-03-21T15:32:45+09:00_2025-03-21T15:32:59+09:00.log": dial tcp: lookup testxxx on ...: no such host : ...

// to-be: 15:32:45 to 15:33:04
I0321 15:33:05.697235       1 basic.go:126] [basic][took 0.014390s] ... 2025-03-21T15:32:45+09:00_2025-03-21T15:33:04+09:00.log
E0321 15:33:05.697456       1 exporter.go:139] Post "http://testxxx/2025-03-21T15:32:45+09:00_2025-03-21T15:33:04+09:00.log": dial tcp: lookup testxxx on ...: no such host : ...

// to-be
// After 3 failures (live factor), delete the receipt.
// This level of failure is considered a storage issue, and the case will be addressed when detected.
I0321 15:33:05.697589       1 counter.go:96] delete stale receipts xxx : {0 2025-03-21 15:32:45 +0900 KST 5s 2025-03-21 15:32:45 +0900 KST}

// to-be
// Resume from 15:33:05
I0321 15:33:10.659044       1 basic.go:126] [basic][took 0.004940s] ... 2025-03-21T15:33:05+09:00_2025-03-21T15:33:09+09:00.log
```