### PR TITLE
fix uploader log to check the actual log time

### DIFF
--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -293,10 +293,7 @@ func (e *LogExporter) getAndExportLogs(uploader uploader.Uploader, request query
 			return time.Time{}, 0, err
 		}
 
-		fileName := uploader.FileName(pStart, pEnd)
-		dir := uploader.Dir(chunk, pStart)
-
-		if err := uploader.Upload(data, dir, fileName); err != nil {
+		if err := uploader.Upload(data, chunk, pStart, pEnd); err != nil {
 			return time.Time{}, 0, err
 		}
 

--- a/pkg/lobster/sink/exporter/uploader/basic.go
+++ b/pkg/lobster/sink/exporter/uploader/basic.go
@@ -100,8 +100,12 @@ func (b BasicUploader) Validate() v1.ValidationErrors {
 	return b.Order.LogExportRule.BasicBucket.Validate()
 }
 
-func (b BasicUploader) Upload(data []byte, dir, fileName string) error {
-	var start = time.Now()
+func (b BasicUploader) Upload(data []byte, chunk model.Chunk, pStart, pEnd time.Time) error {
+	var (
+		start    = time.Now()
+		fileName = b.FileName(pStart, pEnd)
+		dir      = b.Dir(chunk, pStart)
+	)
 
 	u, err := url.Parse(b.Order.LogExportRule.BasicBucket.Destination)
 	if err != nil {
@@ -123,7 +127,8 @@ func (b BasicUploader) Upload(data []byte, dir, fileName string) error {
 	}
 
 	defer func() {
-		glog.Infof("[basic][took %fs] upload %d bytes to %s", time.Since(start).Seconds(), len(data), u.String())
+		glog.Infof("[basic][took %fs][%d_%d] upload %d bytes to %s for %s",
+			time.Since(start).Seconds(), pStart.Unix(), pEnd.Unix(), len(data), u.String(), chunk.Key())
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/pkg/lobster/sink/exporter/uploader/kafka.go
+++ b/pkg/lobster/sink/exporter/uploader/kafka.go
@@ -74,11 +74,12 @@ func (k KafkaUploader) Validate() v1.ValidationErrors {
 	return k.Order.LogExportRule.Kafka.Validate()
 }
 
-func (k KafkaUploader) Upload(data []byte, dir, fileName string) error {
+func (k KafkaUploader) Upload(data []byte, chunk model.Chunk, pStart, pEnd time.Time) error {
 	var start = time.Now()
 
 	defer func() {
-		glog.Infof("[kafka][took %fs] upload %d bytes to topic `%s` for %s", time.Since(start).Seconds(), len(data), k.Order.LogExportRule.Kafka.Topic, k.Order.Request.String())
+		glog.Infof("[kafka][took %fs][%d_%d] upload %d bytes to topic `%s` for %s",
+			time.Since(start).Seconds(), pStart.Unix(), pEnd.Unix(), len(data), k.Order.LogExportRule.Kafka.Topic, chunk.Key())
 	}()
 
 	config, err := k.newConfig(k.Order.LogExportRule.Kafka)

--- a/pkg/lobster/sink/exporter/uploader/uploader.go
+++ b/pkg/lobster/sink/exporter/uploader/uploader.go
@@ -33,12 +33,10 @@ const (
 )
 
 type Uploader interface {
-	Upload([]byte, string, string) error
+	Upload([]byte, model.Chunk, time.Time, time.Time) error
 	Interval() time.Duration
 	Type() string
 	Name() string
-	Dir(model.Chunk, time.Time) string
-	FileName(time.Time, time.Time) string
 	Validate() v1.ValidationErrors
 }
 


### PR DESCRIPTION
- The logging for the uploading process previously used the time in `order.request` as a reference, but it will be changed to use the actual log timestamp instead
- This change helps reduce potential misunderstandings caused by time differences between the request and the retrieved log
  - Related issue: https://github.com/naver/lobster/pull/46