### PR TITLE
ensure correct log export start time after retry

### DIFF
--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -228,7 +228,7 @@ func (e *LogExporter) export(current time.Time, uploader uploader.Uploader, orde
 	start, end := e.makeTimeRange(receipt.LogTime, current)
 	logTs, total, err := e.getAndExportLogs(uploader, order.Request, chunk, start, end)
 	if logTs.IsZero() {
-		logTs = current
+		logTs = start
 	}
 
 	if total > 0 {


### PR DESCRIPTION
related: https://github.com/naver/lobster/pull/46

- Although the retry was triggered due to receipt-based retry logic modifications, the start time was not as expected
- In the example below(in the production environment), the start time changed from `09:17:58` to `09:18:32`, causing some logs not to be sent

```
// Failure start time: 09:17:58
I0407 10:18:32.478879       1 basic.go:126] [basic][took 10.189244s] upload 194934272 bytes to xxx/2025-04-07T09:17:58%252B09:00_2025-04-07T10:17:43%252B09:00.log
E0407 10:18:32.479175       1 exporter.go:141] Post "xxx/2025-04-07T09:17:58%252B09:00_2025-04-07T10:17:43%252B09:00.log": context deadline exceeded : ....
```

```
// Retry start time: 09:18:32
I0407 10:18:56.715621       1 basic.go:126] [basic][took 1.595640s] upload 195086287 bytes to xxx/2025-04-07T09:18:32%252B09:00_2025-04-07T10:18:15%252B09:00.log
```