### PR TITLE
fix label comparison

### DIFF
--- a/pkg/lobster/distributor/distributor.go
+++ b/pkg/lobster/distributor/distributor.go
@@ -150,7 +150,7 @@ func (d *Distributor) updateLabelsInChunks(podMap map[string]v1.Pod) {
 			return
 		}
 
-		if reflect.DeepEqual(chunk.Labels, pod.Labels) {
+		if reflect.DeepEqual(map[string]string(chunk.Labels), pod.Labels) {
 			return
 		}
 


### PR DESCRIPTION
- High disk write IOPS were observed on certain nodes
- CPU profiling revealed that most of the time was spent on updating pod labels(including writing to disk)
- Due to repeated comparison failures between chunk labels and pod labels, the lobster store kept writing pod labels to disk, which caused increased write IOPS