### PR TITLE
add options to adjust the timeout for responses that include more blocks

### DIFF
--- a/pkg/lobster/global/config.go
+++ b/pkg/lobster/global/config.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 )
 
 const MaxBytes = 1024 * 1024 * 1024 // 1 gib
@@ -36,10 +37,12 @@ func (a *LobsterQueries) Set(addr string) error {
 }
 
 type config struct {
-	LobsterQueries *LobsterQueries
-	PageBurst      *int
-	ExportLimit    *int
-	ContentsLimit  *uint64
+	LobsterQueries             *LobsterQueries
+	PageBurst                  *int
+	ExportLimit                *int
+	ContentsLimit              *uint64
+	FetchTimeout               *time.Duration
+	FetchResponseHeaderTimeout *time.Duration
 }
 
 func setup() config {
@@ -48,11 +51,15 @@ func setup() config {
 	pageBurst := flag.Int("global.pageBurst", 1000, "Provide lines in and out of busrt per page")
 	limit := flag.Int("global.exportlLimit", MaxBytes, fmt.Sprintf("limit in bytes (0 < limit < %d)", MaxBytes))
 	contentsLimit := flag.Uint64("global.contentsLimit", 1000*1000*30, "Limit the amount of responsive content per page")
+	fetchTimeout := flag.Duration("global.fetchTimeout", 10*time.Second, "Response timeout for log requests")
+	fetchResponseHeaderTimeout := flag.Duration("global.fetchResponseHeaderTimeout", 10*time.Second, "Header response timeout for log requests; delays may occur during file reading")
 
 	return config{
-		LobsterQueries: lobsterQueries,
-		PageBurst:      pageBurst,
-		ExportLimit:    limit,
-		ContentsLimit:  contentsLimit,
+		LobsterQueries:             lobsterQueries,
+		PageBurst:                  pageBurst,
+		ExportLimit:                limit,
+		ContentsLimit:              contentsLimit,
+		FetchTimeout:               fetchTimeout,
+		FetchResponseHeaderTimeout: fetchResponseHeaderTimeout,
 	}
 }

--- a/pkg/lobster/global/querier.go
+++ b/pkg/lobster/global/querier.go
@@ -36,6 +36,7 @@ var conf config
 
 type Querier struct {
 	broker.Broker
+	querier.Fetcher
 }
 
 func init() {
@@ -65,7 +66,8 @@ func NewQuerier() *Querier {
 
 	glog.Infof("actual clusters after host lookup: %s", strings.Join(clusters, ","))
 	return &Querier{
-		Broker: broker.NewBroker(remoteAddrs),
+		Broker:  broker.NewBroker(remoteAddrs),
+		Fetcher: querier.NewFetcher(*conf.FetchTimeout, *conf.FetchResponseHeaderTimeout),
 	}
 }
 
@@ -90,7 +92,7 @@ func (q *Querier) GetSeriesInBlocksWithinRange(req query.Request) (numOfChunk in
 		return
 	}
 
-	results, err = querier.Fetch(req, chunks, logHandler.PathLogSeries)
+	results, err = q.Fetch(req, chunks, logHandler.PathLogSeries)
 	if err != nil {
 		return
 	}
@@ -122,7 +124,7 @@ func (q *Querier) GetBlocksWithinRange(req query.Request) (data []byte, numOfChu
 		return
 	}
 
-	results, pageInfo, err = querier.FetchLogEntries(req, chunks, limit)
+	results, pageInfo, err = q.GetLogEntries(req, chunks, limit)
 	if err != nil {
 		return
 	}
@@ -160,7 +162,7 @@ func (q *Querier) GetEntriesWithinRange(req query.Request) (data []model.Entry, 
 		return
 	}
 
-	results, pageInfo, err = querier.FetchLogEntries(req, chunks, limit)
+	results, pageInfo, err = q.GetLogEntries(req, chunks, limit)
 	if err != nil {
 		return
 	}

--- a/pkg/lobster/querier/config.go
+++ b/pkg/lobster/querier/config.go
@@ -22,14 +22,16 @@ import (
 )
 
 type config struct {
-	StatusCheckInteval  *time.Duration
-	ChunkRetentionTime  *time.Duration
-	StoreRetentionTime  *time.Duration
-	Id                  *int
-	Modulus             *uint64
-	LookupServicePrefix *string
-	PageBurst           *int
-	ContentsLimit       *uint64
+	StatusCheckInteval         *time.Duration
+	ChunkRetentionTime         *time.Duration
+	StoreRetentionTime         *time.Duration
+	Id                         *int
+	Modulus                    *uint64
+	LookupServicePrefix        *string
+	PageBurst                  *int
+	ContentsLimit              *uint64
+	FetchTimeout               *time.Duration
+	FetchResponseHeaderTimeout *time.Duration
 }
 
 func setup() config {
@@ -41,15 +43,19 @@ func setup() config {
 	lookupServicePrefix := flag.String("querier.member.lookup-service-prefix", "lobster-query-shard", "Prefix of service of lobster-querier")
 	pageBurst := flag.Int("querier.pageBurst", 1000, "Provide lines in and out of busrt per page")
 	contentsLimit := flag.Uint64("querier.contentsLimit", 1000*1000*30, "Limit the amount of responsive content per page")
+	fetchTimeout := flag.Duration("querier.fetchTimeout", 10*time.Second, "Response timeout for log requests")
+	fetchResponseHeaderTimeout := flag.Duration("querier.fetchResponseHeaderTimeout", 10*time.Second, "Header response timeout for log requests; delays may occur during file reading")
 
 	return config{
-		StatusCheckInteval:  statusCheckInteval,
-		ChunkRetentionTime:  chunkRetentionTime,
-		StoreRetentionTime:  storeRetentionTime,
-		Id:                  id,
-		Modulus:             modulus,
-		LookupServicePrefix: lookupServicePrefix,
-		PageBurst:           pageBurst,
-		ContentsLimit:       contentsLimit,
+		StatusCheckInteval:         statusCheckInteval,
+		ChunkRetentionTime:         chunkRetentionTime,
+		StoreRetentionTime:         storeRetentionTime,
+		Id:                         id,
+		Modulus:                    modulus,
+		LookupServicePrefix:        lookupServicePrefix,
+		PageBurst:                  pageBurst,
+		ContentsLimit:              contentsLimit,
+		FetchTimeout:               fetchTimeout,
+		FetchResponseHeaderTimeout: fetchResponseHeaderTimeout,
 	}
 }


### PR DESCRIPTION
- Provide options to configure both the overall request timeout and the response header timeout
- By default, the size per container is limited, but when this limit is increased(adjustable), more time is required to read each block
- If reading blocks takes longer, a response header timeout may occur in querier(and global querier), so this should be adjustable too