### PR TITLE
change the log search offset unit for log export to milliseconds

### DIFF
--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -247,7 +247,7 @@ func (e *LogExporter) makeTimeRange(logTime, current time.Time) (time.Time, time
 		return current.Add(-*conf.MaxLookback), current
 	}
 
-	return logTime.Add(time.Nanosecond), current
+	return logTime.Add(time.Millisecond), current
 }
 
 func (e *LogExporter) getAndExportLogs(uploader uploader.Uploader, request query.Request, chunk model.Chunk, start, end time.Time) (time.Time, int, error) {

--- a/pkg/lobster/sink/exporter/uploader/basic.go
+++ b/pkg/lobster/sink/exporter/uploader/basic.go
@@ -128,7 +128,7 @@ func (b BasicUploader) Upload(data []byte, chunk model.Chunk, pStart, pEnd time.
 
 	defer func() {
 		glog.Infof("[basic][took %fs][%d_%d] upload %d bytes to %s for %s",
-			time.Since(start).Seconds(), pStart.Unix(), pEnd.Unix(), len(data), u.String(), chunk.Key())
+			time.Since(start).Seconds(), pStart.UnixMilli(), pEnd.UnixMilli(), len(data), u.String(), chunk.Key())
 	}()
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/pkg/lobster/sink/exporter/uploader/kafka.go
+++ b/pkg/lobster/sink/exporter/uploader/kafka.go
@@ -79,7 +79,7 @@ func (k KafkaUploader) Upload(data []byte, chunk model.Chunk, pStart, pEnd time.
 
 	defer func() {
 		glog.Infof("[kafka][took %fs][%d_%d] upload %d bytes to topic `%s` for %s",
-			time.Since(start).Seconds(), pStart.Unix(), pEnd.Unix(), len(data), k.Order.LogExportRule.Kafka.Topic, chunk.Key())
+			time.Since(start).Seconds(), pStart.UnixMilli(), pEnd.UnixMilli(), len(data), k.Order.LogExportRule.Kafka.Topic, chunk.Key())
 	}()
 
 	config, err := k.newConfig(k.Order.LogExportRule.Kafka)

--- a/pkg/lobster/sink/exporter/uploader/s3.go
+++ b/pkg/lobster/sink/exporter/uploader/s3.go
@@ -120,7 +120,7 @@ func (s S3Uploader) Upload(data []byte, chunk model.Chunk, pStart, pEnd time.Tim
 
 	defer func() {
 		glog.Infof("[s3][took %fs][%d_%d] upload %d bytes to %s(%s) for %s",
-			time.Since(start).Seconds(), pStart.Unix(), pEnd.Unix(), len(data), *input.Bucket, *input.Key, chunk.Key())
+			time.Since(start).Seconds(), pStart.UnixMilli(), pEnd.UnixMilli(), len(data), *input.Bucket, *input.Key, chunk.Key())
 	}()
 
 	if _, err := s3manager.NewUploader(s3Session).Upload(input); err != nil {


### PR DESCRIPTION
- Unify log granularity(in log search) to millisecond precision
- Strengthen internal logging