### PR TITLE
support exactly-once delivery for Kafka messages

### DIFF
--- a/pkg/lobster/sink/exporter/uploader/kafka.go
+++ b/pkg/lobster/sink/exporter/uploader/kafka.go
@@ -104,6 +104,9 @@ func (k KafkaUploader) newConfig(kafka *v1.Kafka) (*sarama.Config, error) {
 	config := sarama.NewConfig()
 	config.ClientID = defaultClientId
 	config.Producer.Return.Successes = true
+	config.Producer.Idempotent = true
+	config.Producer.RequiredAcks = sarama.WaitForAll
+	config.Net.MaxOpenRequests = 1
 	config.Net.DialTimeout = dialTimeout
 
 	if kafka.TLS.Enable {


### PR DESCRIPTION
- Support Kafka idempotence(exactly-once) settings to prevent confusion caused by duplicate messages in Kafka broker
- ref: https://github.com/IBM/sarama/blob/main/config.go#L201