### PR TITLE
Fix to avoid filtering chunks based on the latest pod information from kubelet

### DIFF
--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -32,7 +32,6 @@ import (
 	"github.com/naver/lobster/pkg/lobster/sink/exporter/counter"
 	"github.com/naver/lobster/pkg/lobster/sink/exporter/uploader"
 	"github.com/naver/lobster/pkg/lobster/sink/exporter/uploader/auth"
-	"github.com/naver/lobster/pkg/lobster/sink/helper"
 	"github.com/naver/lobster/pkg/lobster/sink/manager"
 	"github.com/naver/lobster/pkg/lobster/sink/order"
 	"github.com/naver/lobster/pkg/lobster/store"
@@ -102,17 +101,12 @@ func (e *LogExporter) Run(stopChan chan struct{}) {
 			now := time.Now()
 			current := now.Truncate(time.Second)
 			newOrders := map[string]order.Order{}
-			podMap := e.client.GetPods()
-
-			if len(podMap) == 0 {
-				panic("no pods found")
-			}
 
 			if err := e.initStore(current); err != nil {
 				glog.Error(err)
 				continue
 			}
-			if err := e.sinkManager.Update(helper.FilterChunksByExistingPods(e.store.GetChunks(), podMap), current.Add(-*conf.InspectInterval), current); err != nil {
+			if err := e.sinkManager.Update(e.store.GetChunks(), current.Add(-*conf.InspectInterval), current); err != nil {
 				glog.Error(err)
 				continue
 			}


### PR DESCRIPTION
## Summary
- Instead of filtering old log metadata(chunks) using the latest Pod information, the lobster system now uses logs from the lookback window (default: 1 hour) as-is for log exportation
  - In https://github.com/naver/lobster/pull/44, I implemented a process to request log data that has changed within the time range from now to lookback (default: 1 hour) via gRPC to store
- If kubelet filters logs based on the latest Pod information, logs from a Pod that has moved to another node can be excluded from exportation, since the old Pod metadata no longer matches 
- This change ensures that logs from relocated Pods are not omitted

## Case review

```
// Log upload configured for 1-minute intervals
I1017 14:35:51.880288       1 basic.go:130] [basic][took 0.157050s][1760679311452_1760679341452] upload 310 bytes to http://xxx/logging/2025-10/log-test/export/export_multiple_clusters/loggen-74bd4c695f-9x74p/loggen2/2025-10-17T14:35:11+09:00_2025-10-17T14:35:41+09:00.log for log-test_loggen-74bd4c695f_loggen-74bd4c695f-9x74p_7071973e-5598-4839-b456-5eb54c49e365_loggen2_stdstream

// Pod deleted -> reassigned to another node, 
// new pod's start timestamp: "2025-10-17T05:35:59Z"

// Log exportation is performed after a new Pod is started on another node; Continuity check for 1760679311452_1760679341452
I1017 14:36:16.801656       1 basic.go:130] [basic][took 0.249149s][1760679341452_1760679341452] upload 155 bytes to http://xxx/logging/ai1/pt/2025-10-17_14:35/log-test/export/export_ai1/loggen-74bd4c695f-9x74p/loggen2/2025-10-17T14:35:41%252B09:00_2025-10-17T14:35:41%252B09:00.log for log-test_loggen-74bd4c695f_loggen-74bd4c695f-9x74p_7071973e-5598-4839-b456-5eb54c49e365_loggen2_stdstream
```