### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-lobster.yaml
+++ b/.github/workflows/go-lobster.yaml
@@ -1,4 +1,6 @@
 name: golang - linter for lobster
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/naver/lobster/security/code-scanning/1](https://github.com/naver/lobster/security/code-scanning/1)

To fix the problem, we need to add a `permissions` block to the workflow, specifying that the job only requires read-only access to repository contents via GITHUB_TOKEN. The best way is to add the block at the workflow root level—just after the workflow name and before the `on:` block—setting `contents: read`. This will apply the restriction to all jobs in the workflow, unless otherwise overridden. No new imports, methods, or other changes are required; only an edit to the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
