### PR TITLE
Add support for configuring PriorityClass per component

### DIFF
--- a/deploy/templates/global-query/deployment.yaml
+++ b/deploy/templates/global-query/deployment.yaml
@@ -18,7 +18,11 @@ spec:
         app: lobster-global-query
       annotations: {{ (default dict .Values.global_query.pod.annotations) | toYaml | nindent 8 }}
     spec:
+      {{- if .Values.global_query.pod.priorityClassName }}
+      priorityClassName: {{ .Values.global_query.pod.priorityClassName }}
+      {{- else if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       serviceAccountName: default
       affinity: {{ (default dict .Values.global_query.pod.affinity) | toYaml | nindent 8 }}
       containers:

--- a/deploy/templates/loggen/deployment.yaml
+++ b/deploy/templates/loggen/deployment.yaml
@@ -18,7 +18,11 @@ spec:
         purpose: logging
       annotations: {{ (default dict .Values.loggen.pod.annotations) | toYaml | nindent 8 }}
     spec:
+      {{- if .Values.loggen.pod.priorityClassName }}
+      priorityClassName: {{ .Values.loggen.pod.priorityClassName }}
+      {{- else if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       affinity: {{ (default dict .Values.loggen.pod.affinity) | toYaml | nindent 8 }}
       serviceAccountName: default
       containers:

--- a/deploy/templates/operator/deployment.yaml
+++ b/deploy/templates/operator/deployment.yaml
@@ -18,7 +18,11 @@ spec:
         app: lobster-operator
       annotations: {{ (default dict .Values.operator.pod.annotations) | toYaml | nindent 8 }}
     spec:
+      {{- if .Values.operator.pod.priorityClassName }}
+      priorityClassName: {{ .Values.operator.pod.priorityClassName }}
+      {{- else if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       affinity: {{ (default dict .Values.operator.pod.affinity) | toYaml | nindent 8 }}
       serviceAccountName: lobster-operator
       containers:

--- a/deploy/templates/query/deployment.yaml
+++ b/deploy/templates/query/deployment.yaml
@@ -23,7 +23,11 @@ spec:
       annotations:
         {{ (default dict $root.Values.query.pod.annotations) | toYaml | nindent 8 }}
     spec:
+      {{- if $root.Values.query.pod.priorityClassName }}
+      priorityClassName: {{ $root.Values.query.pod.priorityClassName }}
+      {{- else if $root.Values.priorityClassName }}
       priorityClassName: {{ $root.Values.priorityClassName }}
+      {{- end }}
       affinity: {{ (default dict $root.Values.query.pod.affinity) | toYaml | nindent 8 }}
       containers:
         - name: query

--- a/deploy/templates/store/daemonset.yaml
+++ b/deploy/templates/store/daemonset.yaml
@@ -31,7 +31,11 @@ spec:
       securityContext:
         runAsGroup: 0
         runAsUser: 0
+      {{- if .Values.store.pod.priorityClassName }}
+      priorityClassName: {{ .Values.store.pod.priorityClassName }}
+      {{- else if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       containers:
         - name: store
           image: {{ required "this value is required" .Values.registry }}/lobster-store:{{ .Chart.AppVersion }}

--- a/deploy/templates/syncer/deployment.yaml
+++ b/deploy/templates/syncer/deployment.yaml
@@ -16,7 +16,11 @@ spec:
         purpose: logging
         app: lobster-syncer
     spec:
+      {{- if .Values.syncer.pod.priorityClassName }}
+      priorityClassName: {{ .Values.syncer.pod.priorityClassName }}
+      {{- else if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       affinity: {{ (default dict .Values.syncer.pod.affinity) | toYaml | nindent 8 }}
       containers:
         - name: syncer


### PR DESCRIPTION
- The `lobster-store` daemonset is responsible for collecting and exporting logs, and may need to be scheduled with higher priority than other pods
- Therefore, it now supports having a separate PriorityClass to ensure appropriate scheduling precedence