### PR TITLE
Ensure block is removed from memory even if file deletion fails

### DIFF
--- a/pkg/lobster/model/chunk.go
+++ b/pkg/lobster/model/chunk.go
@@ -167,15 +167,17 @@ func (c Chunk) DeleteContainerFiles(blockPath string) error {
 	return os.RemoveAll(fmt.Sprintf("%s/%s", blockPath, c.RelativeBlockDir))
 }
 
-func (c *Chunk) DeleteBlockAt(i int, rootPath string) {
-	_ = os.Remove(fmt.Sprintf("%s/%s/%s", rootPath, c.RelativeBlockDir, c.Blocks[i].FileName()))
+func (c *Chunk) DeleteBlockAt(i int, rootPath string) error {
+	defer func() {
+		if i == 0 && len(c.Blocks) > 1 {
+			c.StartedAt = c.Blocks[1].StartedAt
+		}
+		c.Line = c.Line - c.Blocks[i].Line
+		c.Size = c.Size - c.Blocks[i].Size
+		c.Blocks = append(c.Blocks[:i], c.Blocks[i+1:]...)
+	}()
 
-	if i == 0 && len(c.Blocks) > 1 {
-		c.StartedAt = c.Blocks[1].StartedAt
-	}
-	c.Line = c.Line - c.Blocks[i].Line
-	c.Size = c.Size - c.Blocks[i].Size
-	c.Blocks = append(c.Blocks[:i], c.Blocks[i+1:]...)
+	return os.Remove(fmt.Sprintf("%s/%s/%s", rootPath, c.RelativeBlockDir, c.Blocks[i].FileName()))
 }
 
 func (c Chunk) IsOutdated(retentionTime time.Duration) bool {

--- a/pkg/lobster/store/store.go
+++ b/pkg/lobster/store/store.go
@@ -355,7 +355,9 @@ func (s *Store) cleanChunks() {
 			offset := 0
 			for i, block := range tmp {
 				if block.DeletionMark {
-					chunk.DeleteBlockAt(i-offset, *conf.StoreRootPath)
+					if err := chunk.DeleteBlockAt(i-offset, *conf.StoreRootPath); err != nil {
+						glog.Error(err)
+					}
 					offset = offset + 1
 					glog.V(3).Infof("delete block : %s | [%v ~ %v]\n", block.FileName(), block.StartedAt, block.EndedAt)
 				}


### PR DESCRIPTION
- There is an issue where a file ends up removed (nonexistent) even after the system call to delete it fails
- If file deletion fails, it is not removed from memory; change the logic to remove it from memory regardless of the deletion result