### PR TITLE
Remove unnecessary order cache

### DIFF
--- a/pkg/lobster/distributor/distributor.go
+++ b/pkg/lobster/distributor/distributor.go
@@ -104,8 +104,7 @@ func (d *Distributor) Run(stopChan chan struct{}) {
 				tailList := d.extractTailList(fileMap, *conf.TailFileMaxStale)
 
 				if *conf.ShouldUpdateLogMatcher {
-					now := time.Now()
-					if err := d.matcher.Update(helper.FilterChunksByExistingPods(d.store.GetChunks(), podMap), now.Add(-*conf.FileInspectInterval), now); err != nil {
+					if err := d.matcher.Update(helper.FilterChunksByExistingPods(d.store.GetChunks(), podMap)); err != nil {
 						glog.Error(err)
 					}
 				}

--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -104,7 +104,7 @@ func (e *LogExporter) Run(stopChan chan struct{}) {
 				glog.Error(err)
 				continue
 			}
-			if err := e.sinkManager.Update(e.store.GetChunks(), current.Add(-*conf.InspectInterval), current); err != nil {
+			if err := e.sinkManager.Update(e.store.GetChunks()); err != nil {
 				glog.Error(err)
 				continue
 			}

--- a/pkg/lobster/sink/manager/manager.go
+++ b/pkg/lobster/sink/manager/manager.go
@@ -20,7 +20,6 @@ import (
 	"log"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/naver/lobster/pkg/lobster/client"
@@ -29,7 +28,6 @@ import (
 	"github.com/naver/lobster/pkg/lobster/sink/indexer"
 	"github.com/naver/lobster/pkg/lobster/sink/order"
 	orderSync "github.com/naver/lobster/pkg/lobster/sink/sync"
-	"github.com/naver/lobster/pkg/lobster/util"
 )
 
 var (
@@ -77,12 +75,8 @@ func (m *SinkManager) Range(receiver func(string, order.Order)) {
 	})
 }
 
-func (m *SinkManager) Update(chunks []model.Chunk, start, end time.Time) error {
-	var (
-		tStart    = util.Timestamp{Time: start}
-		tEnd      = util.Timestamp{Time: end}
-		preorders []order.Order
-	)
+func (m *SinkManager) Update(chunks []model.Chunk) error {
+	var preorders []order.Order
 
 	indexer := indexer.New(chunks)
 
@@ -96,7 +90,7 @@ func (m *SinkManager) Update(chunks []model.Chunk, start, end time.Time) error {
 	glog.V(3).Infof("Requests preorders for [%s] | got %d preorders", strings.Join(indexer.GetNamespaces(), ","), len(preorders))
 	metrics.SetReceivingPreorders(float64(len(preorders)))
 
-	orders := order.NewOrdersFromPreorders(preorders, indexer, tStart, tEnd)
+	orders := order.NewOrdersFromPreorders(preorders, indexer)
 	glog.V(3).Infof("%+v", orders)
 
 	m.update(orders)

--- a/pkg/lobster/sink/matcher/matcher.go
+++ b/pkg/lobster/sink/matcher/matcher.go
@@ -54,6 +54,6 @@ func (m *LogMatcher) Match(key, logLine string, logTs time.Time) {
 	}
 }
 
-func (m *LogMatcher) Update(chunks []model.Chunk, start, end time.Time) error {
-	return m.sinkManager.Update(chunks, start, end)
+func (m *LogMatcher) Update(chunks []model.Chunk) error {
+	return m.sinkManager.Update(chunks)
 }

--- a/pkg/lobster/sink/order/helper.go
+++ b/pkg/lobster/sink/order/helper.go
@@ -21,7 +21,6 @@ import (
 	"github.com/naver/lobster/pkg/lobster/metrics"
 	"github.com/naver/lobster/pkg/lobster/querier"
 	"github.com/naver/lobster/pkg/lobster/sink/indexer"
-	"github.com/naver/lobster/pkg/lobster/util"
 )
 
 type Orders map[string][]Order
@@ -40,12 +39,10 @@ func (orders Orders) Append(input Orders) {
 	}
 }
 
-func NewOrdersFromPreorders(preorders []Order, indexer indexer.ChunkIndexer, start, end util.Timestamp) Orders {
+func NewOrdersFromPreorders(preorders []Order, indexer indexer.ChunkIndexer) Orders {
 	orders := Orders{}
 
 	for _, preorder := range preorders {
-		preorder.Request.Start = start
-		preorder.Request.End = end
 		newOrders, err := newOrdersForChunks(preorder, indexer)
 		if err != nil {
 			glog.Error("Invalid order : %s : %s_%s_%s", err.Error(), preorder.SinkNamespace, preorder.SinkName, preorder.RuleName)


### PR DESCRIPTION
related: https://github.com/naver/lobster/pull/69

- Previously, cached recent orders were used to ensure that no logs were missed for the log export process
- Since the log exporter now queries past logs based on the configured `lookback` period, simplify the logic by removing the cache and relying solely on `lookback` to prevent missing logs