### PR TITLE
Add log entry option

### DIFF
--- a/deploy/templates/operator/manifests/crd.yaml
+++ b/deploy/templates/operator/manifests/crd.yaml
@@ -77,6 +77,9 @@ spec:
                     description:
                       description: Description of this rule
                       type: string
+                    enableLogEntryFormat:
+                      description: Enable structured messages to include chunk metadata
+                      type: boolean
                     filter:
                       description: Generate metrics from logs using target or log-based
                         rules

--- a/docs/design/log_sink.md
+++ b/docs/design/log_sink.md
@@ -62,6 +62,7 @@ spec:
   logMetricRules:
   - name: include-error-for-tc-container
     interval: 1m
+    enableLogEntryFormat: false
     filter:
       include: "error”
       labels:
@@ -75,6 +76,7 @@ spec:
       pathTemplate: "/path/{{TimeLayout \"20060102\"}}"
   - name: exclude-GET
     interval: 1h
+    enableLogEntryFormat: false
     filter:
       clusters:
       - clusterA
@@ -96,6 +98,7 @@ spec:
         {label2}: {value2}
   - name: kafka-test
     interval: 5s
+    enableLogEntryFormat: false       # Enable this option to include cluster and pod label metadata in the log message as JSON
     filter:
       include: "error”
       labels:

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/go-openapi/jsonreference v0.21.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
+	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEe
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/go-tomb/tomb v0.0.0-20141024135613-dd632973f1e7 h1:uzIDmrvcAPIrpXCbIqb47rZVw1cVb3+MS+m2UP4A9Fs=
 github.com/go-tomb/tomb v0.0.0-20141024135613-dd632973f1e7/go.mod h1:RBAwp+uBhymHG7YL5Wjwy9uKPyOHOwbtWOZucxDDSl8=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v1.2.4 h1:CNNw5U8lSiiBk7druxtSHHTsRWcxKoac6kZKm2peBBc=

--- a/pkg/docs/global-query/docs.go
+++ b/pkg/docs/global-query/docs.go
@@ -379,6 +379,9 @@ const docTemplate = `{
                 "pod": {
                     "type": "string"
                 },
+                "podUid": {
+                    "type": "string"
+                },
                 "sourcePath": {
                     "type": "string"
                 },
@@ -486,6 +489,10 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "enableLogEntryFormat": {
+                    "type": "boolean",
+                    "default": false
                 },
                 "end": {
                     "description": "End time for query",

--- a/pkg/docs/global-query/swagger.json
+++ b/pkg/docs/global-query/swagger.json
@@ -371,6 +371,9 @@
                 "pod": {
                     "type": "string"
                 },
+                "podUid": {
+                    "type": "string"
+                },
                 "sourcePath": {
                     "type": "string"
                 },
@@ -478,6 +481,10 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "enableLogEntryFormat": {
+                    "type": "boolean",
+                    "default": false
                 },
                 "end": {
                     "description": "End time for query",

--- a/pkg/docs/global-query/swagger.yaml
+++ b/pkg/docs/global-query/swagger.yaml
@@ -59,6 +59,8 @@ definitions:
         type: string
       pod:
         type: string
+      podUid:
+        type: string
       sourcePath:
         type: string
       sourceType:
@@ -134,6 +136,9 @@ definitions:
         items:
           type: string
         type: array
+      enableLogEntryFormat:
+        default: false
+        type: boolean
       end:
         description: End time for query
         type: string

--- a/pkg/docs/operator/docs.go
+++ b/pkg/docs/operator/docs.go
@@ -452,6 +452,10 @@ const docTemplate = `{
                     "description": "Description of this rule",
                     "type": "string"
                 },
+                "enableLogEntryFormat": {
+                    "description": "Enable structured messages to include chunk metadata",
+                    "type": "boolean"
+                },
                 "filter": {
                     "description": "Generate metrics from logs using target or log-based rules",
                     "allOf": [

--- a/pkg/docs/operator/swagger.json
+++ b/pkg/docs/operator/swagger.json
@@ -444,6 +444,10 @@
                     "description": "Description of this rule",
                     "type": "string"
                 },
+                "enableLogEntryFormat": {
+                    "description": "Enable structured messages to include chunk metadata",
+                    "type": "boolean"
+                },
                 "filter": {
                     "description": "Generate metrics from logs using target or log-based rules",
                     "allOf": [

--- a/pkg/docs/operator/swagger.yaml
+++ b/pkg/docs/operator/swagger.yaml
@@ -114,6 +114,9 @@ definitions:
       description:
         description: Description of this rule
         type: string
+      enableLogEntryFormat:
+        description: Enable structured messages to include chunk metadata
+        type: boolean
       filter:
         allOf:
         - $ref: '#/definitions/v1.Filter'

--- a/pkg/docs/query/docs.go
+++ b/pkg/docs/query/docs.go
@@ -379,6 +379,9 @@ const docTemplate = `{
                 "pod": {
                     "type": "string"
                 },
+                "podUid": {
+                    "type": "string"
+                },
                 "sourcePath": {
                     "type": "string"
                 },
@@ -486,6 +489,10 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "enableLogEntryFormat": {
+                    "type": "boolean",
+                    "default": false
                 },
                 "end": {
                     "description": "End time for query",

--- a/pkg/docs/query/swagger.json
+++ b/pkg/docs/query/swagger.json
@@ -371,6 +371,9 @@
                 "pod": {
                     "type": "string"
                 },
+                "podUid": {
+                    "type": "string"
+                },
                 "sourcePath": {
                     "type": "string"
                 },
@@ -478,6 +481,10 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "enableLogEntryFormat": {
+                    "type": "boolean",
+                    "default": false
                 },
                 "end": {
                     "description": "End time for query",

--- a/pkg/docs/query/swagger.yaml
+++ b/pkg/docs/query/swagger.yaml
@@ -59,6 +59,8 @@ definitions:
         type: string
       pod:
         type: string
+      podUid:
+        type: string
       sourcePath:
         type: string
       sourceType:
@@ -134,6 +136,9 @@ definitions:
         items:
           type: string
         type: array
+      enableLogEntryFormat:
+        default: false
+        type: boolean
       end:
         description: End time for query
         type: string

--- a/pkg/lobster/global/querier.go
+++ b/pkg/lobster/global/querier.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/naver/lobster/pkg/lobster/metrics"
@@ -107,7 +108,7 @@ func (q *Querier) GetSeriesInBlocksWithinRange(req query.Request) (numOfChunk in
 	return
 }
 
-func (q *Querier) GetBlocksWithinRange(req query.Request) (data []byte, numOfChunk int, pageInfo model.PageInfo, err error) {
+func (q *Querier) GetBlocksWithinRange(req query.Request) (data []byte, _, _ time.Time, numOfChunk int, pageInfo model.PageInfo, err error) {
 	var (
 		chunks           []model.Chunk
 		results          []querier.FetchResult

--- a/pkg/lobster/model/entry.go
+++ b/pkg/lobster/model/entry.go
@@ -24,13 +24,13 @@ type Entry struct {
 	Timestamp  time.Time         `json:"time"`
 	SourceType string            `json:"sourceType"`
 	SourcePath string            `json:"sourcePath"`
-	Stream     string            `json:"stream"`
-	Tag        string            `json:"tag"`
+	Stream     string            `json:"stream,omitempty"`
+	Tag        string            `json:"tag,omitempty"`
 	Cluster    string            `json:"cluster"`
 	Namespace  string            `json:"namespace"`
 	Labels     map[string]string `json:"labels"`
 	Pod        string            `json:"pod"`
-	PodUid     string            `json:"podUid"`
+	PodUid     string            `json:"podUid,omitempty"`
 	Container  string            `json:"container"`
 	Message    string            `json:"message"`
 }

--- a/pkg/lobster/model/entry.go
+++ b/pkg/lobster/model/entry.go
@@ -30,20 +30,30 @@ type Entry struct {
 	Namespace  string            `json:"namespace"`
 	Labels     map[string]string `json:"labels"`
 	Pod        string            `json:"pod"`
+	PodUid     string            `json:"podUid"`
 	Container  string            `json:"container"`
 	Message    string            `json:"message"`
 }
 
-func NewEntry(c Chunk) Entry {
+func NewEntryFromChunk(c Chunk) Entry {
 	return Entry{
 		SourceType: c.Source.Type,
 		SourcePath: c.Source.Path,
 		Cluster:    c.Cluster,
 		Namespace:  c.Namespace,
 		Pod:        c.Pod,
+		PodUid:     c.PodUid,
 		Container:  c.Container,
 		Labels:     c.Labels,
 	}
+}
+
+func NewEntry(ts time.Time, c Chunk, message string) Entry {
+	e := NewEntryFromChunk(c)
+	e.Timestamp = ts
+	e.Message = message
+
+	return e
 }
 
 func (e Entry) String() string {

--- a/pkg/lobster/model/entry_bench_test.go
+++ b/pkg/lobster/model/entry_bench_test.go
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	gojson "github.com/goccy/go-json"
+)
+
+// createTestChunk creates a test chunk for benchmarking
+func createTestChunk() Chunk {
+	return Chunk{
+		Id:        "test-chunk-123",
+		Cluster:   "production-cluster",
+		Namespace: "default",
+		Labels: Labels{
+			"app":         "web-server",
+			"environment": "production",
+			"version":     "v1.2.3",
+			"team":        "platform",
+		},
+		SetName:   "web-deployment",
+		Pod:       "web-server-abc123-xyz789",
+		PodUid:    "550e8400-e29b-41d4-a716-446655440000",
+		Container: "nginx",
+		Source: Source{
+			Type: "kubernetes",
+			Path: "/var/log/pods/default_web-server-abc123-xyz789_550e8400/nginx/0.log",
+		},
+		StartedAt: time.Now(),
+		UpdatedAt: time.Now(),
+		Line:      10000,
+		Size:      1024000,
+	}
+}
+
+var (
+	testChunk     = createTestChunk()
+	testTimestamp = time.Now()
+	testMessages  = []string{
+		"[INFO] 2024-01-21 10:15:30 - Server started successfully on port 8080",
+		"[ERROR] 2024-01-21 10:15:31 - Failed to connect to database: connection timeout after 30s",
+		"[WARN] 2024-01-21 10:15:32 - High memory usage detected: 85% of available memory in use",
+		"[DEBUG] 2024-01-21 10:15:33 - Processing request: GET /api/v1/users?page=1&limit=100",
+		`[INFO] 2024-01-21 10:15:34 - JSON response: {"status":"ok","data":{"users":[{"id":1,"name":"John"}]}}`,
+	}
+)
+
+// BenchmarkEntry_StdlibJSON benchmarks using standard library encoding/json
+func BenchmarkEntry_StdlibJSON(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		msg := testMessages[i%len(testMessages)]
+		entry := NewEntry(testTimestamp, testChunk, msg)
+		_, err := json.Marshal(entry)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEntry_GoccyJSON benchmarks using goccy/go-json library
+func BenchmarkEntry_GoccyJSON(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		msg := testMessages[i%len(testMessages)]
+		entry := NewEntry(testTimestamp, testChunk, msg)
+		_, err := gojson.Marshal(entry)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkEntry_GoccyJSON_Parallel benchmarks parallel JSON marshaling (real-world scenario)
+func BenchmarkEntry_GoccyJSON_Parallel(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			msg := testMessages[i%len(testMessages)]
+			entry := NewEntry(testTimestamp, testChunk, msg)
+			_, err := gojson.Marshal(entry)
+			if err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+}
+
+// BenchmarkEntry_ByMessageSize benchmarks performance with different message sizes
+func BenchmarkEntry_ByMessageSize(b *testing.B) {
+	sizes := []struct {
+		name string
+		msg  string
+	}{
+		{"Short", "Error occurred"},
+		{"Medium", testMessages[0]},
+		{"Long", testMessages[4]},
+		{"VeryLong", string(make([]byte, 1024))}, // 1KB message
+	}
+
+	for _, size := range sizes {
+		b.Run(size.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				entry := NewEntry(testTimestamp, testChunk, size.msg)
+				_, err := gojson.Marshal(entry)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkEntry_Creation measures the overhead of Entry creation only
+func BenchmarkEntry_Creation(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		msg := testMessages[i%len(testMessages)]
+		_ = NewEntry(testTimestamp, testChunk, msg)
+	}
+}
+
+// BenchmarkEntry_FullPipeline benchmarks the complete pipeline (creation + marshaling + append)
+func BenchmarkEntry_FullPipeline(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		msg := testMessages[i%len(testMessages)]
+		entry := NewEntry(testTimestamp, testChunk, msg)
+		data, err := gojson.Marshal(entry)
+		if err != nil {
+			b.Fatal(err)
+		}
+		// In actual usage: buffer.Write(ts, append(data, '\n'))
+		_ = append(data, '\n')
+	}
+}
+
+// BenchmarkEntry_ByLabelsSize benchmarks performance with different numbers of labels
+func BenchmarkEntry_ByLabelsSize(b *testing.B) {
+	createChunkWithLabels := func(n int) Chunk {
+		chunk := testChunk
+		chunk.Labels = make(Labels)
+		for i := 0; i < n; i++ {
+			chunk.Labels[string(rune('a'+i))] = "value"
+		}
+		return chunk
+	}
+
+	sizes := []int{0, 5, 10, 20, 50}
+	for _, size := range sizes {
+		b.Run(string(rune('0'+size/10))+string(rune('0'+size%10))+"_labels", func(b *testing.B) {
+			chunk := createChunkWithLabels(size)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				entry := NewEntry(testTimestamp, chunk, testMessages[0])
+				_, err := gojson.Marshal(entry)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkEntry_Allocations measures memory allocation patterns
+func BenchmarkEntry_Allocations(b *testing.B) {
+	b.Run("WithAllocation", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			entry := NewEntry(testTimestamp, testChunk, testMessages[0])
+			data, _ := gojson.Marshal(entry)
+			result := append(data, '\n')
+			_ = result
+		}
+	})
+
+	b.Run("PreallocatedBuffer", func(b *testing.B) {
+		b.ReportAllocs()
+		buf := make([]byte, 0, 1024)
+		for i := 0; i < b.N; i++ {
+			entry := NewEntry(testTimestamp, testChunk, testMessages[0])
+			data, _ := gojson.Marshal(entry)
+			buf = append(buf[:0], data...)
+			buf = append(buf, '\n')
+			_ = buf
+		}
+	})
+}

--- a/pkg/lobster/querier/entry.go
+++ b/pkg/lobster/querier/entry.go
@@ -34,7 +34,7 @@ type ParseFunc func(string, model.Chunk) (model.Entry, error)
 
 func ParseEntry(line string, chunk model.Chunk) (model.Entry, error) {
 	var (
-		e   = model.NewEntry(chunk)
+		e   = model.NewEntryFromChunk(chunk)
 		err error
 	)
 
@@ -69,7 +69,7 @@ func ParseEntry(line string, chunk model.Chunk) (model.Entry, error) {
 
 func ParseEntryRaw(line string, chunk model.Chunk) (model.Entry, error) {
 	var (
-		e   = model.NewEntry(chunk)
+		e   = model.NewEntryFromChunk(chunk)
 		err error
 	)
 

--- a/pkg/lobster/querier/querier.go
+++ b/pkg/lobster/querier/querier.go
@@ -142,7 +142,7 @@ func (q *Querier) GetSeriesInBlocksWithinRange(req query.Request) (numOfChunk in
 	return
 }
 
-func (q *Querier) GetBlocksWithinRange(req query.Request) (data []byte, numOfChunk int, pageInfo model.PageInfo, err error) {
+func (q *Querier) GetBlocksWithinRange(req query.Request) (data []byte, _, _ time.Time, numOfChunk int, pageInfo model.PageInfo, err error) {
 	var (
 		chunks           []model.Chunk
 		remoteChunks     []model.Chunk

--- a/pkg/lobster/query/query.go
+++ b/pkg/lobster/query/query.go
@@ -16,12 +16,16 @@
 
 package query
 
-import "github.com/naver/lobster/pkg/lobster/model"
+import (
+	"time"
+
+	"github.com/naver/lobster/pkg/lobster/model"
+)
 
 type Queryable interface {
 	GetChunksWithinRange(Request) ([]model.Chunk, error)
 	GetSeriesInBlocksWithinRange(Request) (int, model.SeriesData, error)
-	GetBlocksWithinRange(Request) ([]byte, int, model.PageInfo, error)
+	GetBlocksWithinRange(Request) ([]byte, time.Time, time.Time, int, model.PageInfo, error)
 	GetEntriesWithinRange(Request) ([]model.Entry, int, model.PageInfo, error)
 	Validate(Request) error
 }

--- a/pkg/lobster/query/request.go
+++ b/pkg/lobster/query/request.go
@@ -72,10 +72,11 @@ type Request struct {
 	FilterExcludeExpr string            `json:"exclude,omitempty"`
 	Filterers         []filter.Filterer `json:"-"`
 	// Use internally
-	Local         bool   `json:"local,omitempty" default:"false"`
-	Attachment    bool   `json:"attachment,omitempty" default:"false"`
-	Version       string `json:"-"`
-	ContentsLimit uint64 `json:"-"`
+	Local                bool   `json:"local,omitempty" default:"false"`
+	Attachment           bool   `json:"attachment,omitempty" default:"false"`
+	Version              string `json:"-"`
+	ContentsLimit        uint64 `json:"-"`
+	EnableLogEntryFormat bool   `json:"enableLogEntryFormat,omitempty" default:"false"`
 }
 
 func ParseRequestWithBody(body []byte) (Request, error) {

--- a/pkg/lobster/server/handler/log/range.go
+++ b/pkg/lobster/server/handler/log/range.go
@@ -62,7 +62,7 @@ func (h RangeHandler) ServeForStringContents(req query.Request, w http.ResponseW
 		return
 	}
 
-	contents, numOfChunk, pageInfo, err := h.Querier.GetBlocksWithinRange(req)
+	contents, _, _, numOfChunk, pageInfo, err := h.Querier.GetBlocksWithinRange(req)
 	if err != nil {
 		errors.HandleError(w, err)
 		glog.Error(err)

--- a/pkg/lobster/server/handler/web/web.go
+++ b/pkg/lobster/server/handler/web/web.go
@@ -58,7 +58,7 @@ func (h WebHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				glog.Error(err)
 			}
 
-			contents, _, pageInfo, err := h.Querier.GetBlocksWithinRange(req)
+			contents, _, _, _, pageInfo, err := h.Querier.GetBlocksWithinRange(req)
 			if err != nil {
 				glog.Error(err)
 			}

--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -213,6 +213,7 @@ func (e *LogExporter) export(current time.Time, uploader uploader.Uploader, orde
 		return 0, nil
 	}
 
+	order.Request.EnableLogEntryFormat = order.LogExportRule.EnableLogEntryFormat
 	start, end := e.makeTimeRange(receipt.LogTime, current)
 	logTs, total, err := e.getAndExportLogs(uploader, order.Request, chunk, start, end)
 	if logTs.IsZero() {

--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -17,14 +17,12 @@
 package exporter
 
 import (
-	"bytes"
 	"context"
 	"log"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/naver/lobster/pkg/lobster/client"
-	"github.com/naver/lobster/pkg/lobster/logline"
 	"github.com/naver/lobster/pkg/lobster/metrics"
 	"github.com/naver/lobster/pkg/lobster/model"
 	"github.com/naver/lobster/pkg/lobster/proto"
@@ -264,23 +262,13 @@ func (e *LogExporter) getAndExportLogs(uploader uploader.Uploader, request query
 			return time.Time{}, 0, err
 		}
 
-		data, _, _, err := e.store.GetBlocksWithinRange(subReq)
+		data, pStart, pEnd, _, _, err := e.store.GetBlocksWithinRange(subReq)
 		if err != nil {
 			return time.Time{}, 0, err
 		}
 
 		if len(data) == 0 {
 			return time.Time{}, 0, nil
-		}
-
-		pStart, err := parseStart(data)
-		if err != nil {
-			return time.Time{}, 0, err
-		}
-
-		pEnd, err := parseEnd(data)
-		if err != nil {
-			return time.Time{}, 0, err
 		}
 
 		if err := uploader.Upload(data, chunk, pStart, pEnd); err != nil {
@@ -294,32 +282,4 @@ func (e *LogExporter) getAndExportLogs(uploader uploader.Uploader, request query
 	}
 
 	return ts, total, nil
-}
-
-func parseStart(data []byte) (time.Time, error) {
-	index := bytes.IndexAny(data, "\n")
-	if index < 0 {
-		t, err := logline.ParseTimestamp(string(data))
-		if err != nil {
-			return time.Time{}, errors.Wrap(err, "failed to parse start")
-		}
-
-		return t, nil
-	}
-
-	return logline.ParseTimestamp(string(data[:index]))
-}
-
-func parseEnd(data []byte) (time.Time, error) {
-	index := bytes.LastIndexAny(data[:len(data)-2], "\n")
-	if index < 0 {
-		t, err := logline.ParseTimestamp(string(data))
-		if err != nil {
-			return time.Time{}, errors.Wrap(err, "failed to parse end")
-		}
-
-		return t, nil
-	}
-
-	return logline.ParseTimestamp(string(data[index+1:]))
 }

--- a/pkg/lobster/store/reader.go
+++ b/pkg/lobster/store/reader.go
@@ -28,9 +28,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/golang/glog"
 	"github.com/naver/lobster/pkg/lobster/logline"
 	"github.com/naver/lobster/pkg/lobster/model"
+	"github.com/naver/lobster/pkg/lobster/query"
 	"github.com/naver/lobster/pkg/lobster/query/filter"
 	"github.com/naver/lobster/pkg/lobster/util"
 	"github.com/ncw/directio"
@@ -228,21 +230,21 @@ func loadTempBlock(filePath string, fileNum int64) (*model.TempBlock, error) {
 	return &model.TempBlock{StartedAt: start, EndedAt: end, Line: line, Size: size, FileNum: fileNum}, nil
 }
 
-func readBlocks(chunk model.Chunk, storeRootkDir string, onlySeries bool, start time.Time, end time.Time, filterers ...filter.Filterer) (*ReadBuffer, []model.Bucket, error) {
+func readBlocks(chunk model.Chunk, storeRootkDir string, onlySeries bool, req query.Request) (*ReadBuffer, []model.Bucket, error) {
 	buffer := NewReadBuffer()
-	blocks := chunk.GetBlocksAfterTime(start)
-	bucketBuilder := model.NewBucketBuilder(start, chunk)
+	blocks := chunk.GetBlocksAfterTime(req.Start.Time)
+	bucketBuilder := model.NewBucketBuilder(req.Start.Time, chunk)
 
-	if start.IsZero() || end.IsZero() {
+	if req.Start.Time.IsZero() || req.End.Time.IsZero() {
 		return nil, []model.Bucket{}, errors.New("invalid range")
 	}
 
 	for _, block := range blocks {
-		if !block.StartTime().Before(end) || !block.EndTime().After(start) {
+		if !block.StartTime().Before(req.End.Time) || !block.EndTime().After(req.Start.Time) {
 			continue
 		}
 
-		skip, err := readBlock(chunk.Source.Type, block, fmt.Sprintf("%s/%s/%s", storeRootkDir, chunk.RelativeBlockDir, block.FileName()), onlySeries, buffer, bucketBuilder, start, end, filterers...)
+		skip, err := readBlock(chunk, block, fmt.Sprintf("%s/%s/%s", storeRootkDir, chunk.RelativeBlockDir, block.FileName()), onlySeries, buffer, bucketBuilder, req)
 		if skip {
 			continue
 		}
@@ -256,7 +258,7 @@ func readBlocks(chunk model.Chunk, storeRootkDir string, onlySeries bool, start 
 	return buffer, bucketBuilder.Build(), nil
 }
 
-func readBlock(sourceType string, block model.ReadableBlock, blockPath string, onlySeries bool, buffer *ReadBuffer, bucketBuilder *model.BucketBuilder, start, end time.Time, filterers ...filter.Filterer) (bool, error) {
+func readBlock(chunk model.Chunk, block model.ReadableBlock, blockPath string, onlySeries bool, buffer *ReadBuffer, bucketBuilder *model.BucketBuilder, req query.Request) (bool, error) {
 	var (
 		blkReader    *blockReader
 		isStartFound bool
@@ -315,24 +317,24 @@ func readBlock(sourceType string, block model.ReadableBlock, blockPath string, o
 			continue
 		}
 
-		if !isStartFound && ts.Before(start) {
+		if !isStartFound && ts.Before(req.Start.Time) {
 			continue
 		}
 		isStartFound = true
 
-		if ts.After(end) {
+		if ts.After(req.End.Time) {
 			break
 		}
 
 		var msg string
 
-		msg, err = logline.ParseLogMessageBySource(sourceType, util.BytesToString(readBuffer))
+		msg, err = logline.ParseLogMessageBySource(chunk.Source.Type, util.BytesToString(readBuffer))
 		if err != nil {
 			glog.Error(err)
 			continue
 		}
 
-		result, err := filter.DoFilter(msg, ts, filterers...)
+		result, err := filter.DoFilter(msg, ts, req.Filterers...)
 		if err != nil {
 			return false, err
 		}
@@ -358,7 +360,17 @@ func readBlock(sourceType string, block model.ReadableBlock, blockPath string, o
 			continue
 		}
 
-		buffer.Write(ts, readBuffer)
+		if req.EnableLogEntryFormat {
+			data, err := json.Marshal(model.NewEntry(ts, chunk, string(readBuffer)))
+			if err != nil {
+				glog.Error(err)
+				continue
+			}
+
+			buffer.Write(ts, append(data, '\n'))
+		} else {
+			buffer.Write(ts, readBuffer)
+		}
 	}
 
 	return false, nil

--- a/pkg/lobster/store/reader.go
+++ b/pkg/lobster/store/reader.go
@@ -367,9 +367,13 @@ func readBlock(chunk model.Chunk, block model.ReadableBlock, blockPath string, o
 				continue
 			}
 
-			buffer.Write(ts, append(data, '\n'))
+			if _, err := buffer.Write(ts, append(data, '\n')); err != nil {
+				return false, err
+			}
 		} else {
-			buffer.Write(ts, readBuffer)
+			if _, err := buffer.Write(ts, readBuffer); err != nil {
+				return false, err
+			}
 		}
 	}
 

--- a/pkg/lobster/store/reader.go
+++ b/pkg/lobster/store/reader.go
@@ -54,6 +54,26 @@ var (
 	largeBlockBufferSize int64 = 30 * 1024 * 1024 // 30mb
 )
 
+type ReadBuffer struct {
+	start, end time.Time
+	buf        *bytes.Buffer
+}
+
+func NewReadBuffer() *ReadBuffer {
+	return &ReadBuffer{
+		buf: &bytes.Buffer{},
+	}
+}
+
+func (rb *ReadBuffer) Write(ts time.Time, data []byte) (int, error) {
+	if rb.start.IsZero() {
+		rb.start = ts
+	}
+
+	rb.end = ts
+	return rb.buf.Write(data)
+}
+
 type blockReader struct {
 	reader *bufio.Reader
 	block  []byte
@@ -208,8 +228,8 @@ func loadTempBlock(filePath string, fileNum int64) (*model.TempBlock, error) {
 	return &model.TempBlock{StartedAt: start, EndedAt: end, Line: line, Size: size, FileNum: fileNum}, nil
 }
 
-func readBlocks(chunk model.Chunk, storeRootkDir string, onlySeries bool, start time.Time, end time.Time, filterers ...filter.Filterer) ([]byte, []model.Bucket, error) {
-	buffer := &bytes.Buffer{}
+func readBlocks(chunk model.Chunk, storeRootkDir string, onlySeries bool, start time.Time, end time.Time, filterers ...filter.Filterer) (*ReadBuffer, []model.Bucket, error) {
+	buffer := NewReadBuffer()
 	blocks := chunk.GetBlocksAfterTime(start)
 	bucketBuilder := model.NewBucketBuilder(start, chunk)
 
@@ -233,10 +253,10 @@ func readBlocks(chunk model.Chunk, storeRootkDir string, onlySeries bool, start 
 
 	bucketBuilder.Save()
 
-	return buffer.Bytes(), bucketBuilder.Build(), nil
+	return buffer, bucketBuilder.Build(), nil
 }
 
-func readBlock(sourceType string, block model.ReadableBlock, blockPath string, onlySeries bool, buffer *bytes.Buffer, bucketBuilder *model.BucketBuilder, start, end time.Time, filterers ...filter.Filterer) (bool, error) {
+func readBlock(sourceType string, block model.ReadableBlock, blockPath string, onlySeries bool, buffer *ReadBuffer, bucketBuilder *model.BucketBuilder, start, end time.Time, filterers ...filter.Filterer) (bool, error) {
 	var (
 		blkReader    *blockReader
 		isStartFound bool
@@ -338,7 +358,7 @@ func readBlock(sourceType string, block model.ReadableBlock, blockPath string, o
 			continue
 		}
 
-		buffer.Write(readBuffer)
+		buffer.Write(ts, readBuffer)
 	}
 
 	return false, nil

--- a/pkg/lobster/store/store.go
+++ b/pkg/lobster/store/store.go
@@ -130,8 +130,11 @@ func (s *Store) GetSeriesInBlocksWithinRange(req query.Request) (numOfChunk int,
 	return
 }
 
-func (s *Store) GetBlocksWithinRange(req query.Request) (data []byte, numOfChunk int, pageInfo model.PageInfo, err error) {
-	var buckets []model.Bucket
+func (s *Store) GetBlocksWithinRange(req query.Request) (data []byte, start, end time.Time, numOfChunk int, pageInfo model.PageInfo, err error) {
+	var (
+		buckets    []model.Bucket
+		readBuffer *ReadBuffer
+	)
 
 	s.lock.RLock()
 	defer s.lock.RUnlock()
@@ -142,10 +145,14 @@ func (s *Store) GetBlocksWithinRange(req query.Request) (data []byte, numOfChunk
 		return
 	}
 
-	data, buckets, err = readBlocks(*chunk, *conf.StoreRootPath, false, req.Start.Time, req.End.Time, req.Filterers...)
+	readBuffer, buckets, err = readBlocks(*chunk, *conf.StoreRootPath, false, req.Start.Time, req.End.Time, req.Filterers...)
 	if err != nil {
 		glog.Error(err)
 	}
+
+	data = readBuffer.buf.Bytes()
+	start = readBuffer.start
+	end = readBuffer.end
 
 	totalLines := int64(0)
 

--- a/pkg/lobster/store/store.go
+++ b/pkg/lobster/store/store.go
@@ -118,7 +118,7 @@ func (s *Store) GetSeriesInBlocksWithinRange(req query.Request) (numOfChunk int,
 		return
 	}
 
-	_, buckets, err = readBlocks(*chunk, *conf.StoreRootPath, true, req.Start.Time, req.End.Time, req.Filterers...)
+	_, buckets, err = readBlocks(*chunk, *conf.StoreRootPath, true, req)
 	if err != nil {
 		glog.Error(err)
 	}
@@ -145,7 +145,7 @@ func (s *Store) GetBlocksWithinRange(req query.Request) (data []byte, start, end
 		return
 	}
 
-	readBuffer, buckets, err = readBlocks(*chunk, *conf.StoreRootPath, false, req.Start.Time, req.End.Time, req.Filterers...)
+	readBuffer, buckets, err = readBlocks(*chunk, *conf.StoreRootPath, false, req)
 	if err != nil {
 		glog.Error(err)
 	}

--- a/pkg/operator/api/v1/logExportRule.go
+++ b/pkg/operator/api/v1/logExportRule.go
@@ -43,6 +43,8 @@ type LogExportRule struct {
 	Filter Filter `json:"filter,omitempty"`
 	// Interval to export logs
 	Interval metav1.Duration `json:"interval,omitempty" swaggertype:"string" example:"time duration(e.g. 1m)"`
+	// Enable structured messages to include chunk metadata
+	EnableLogEntryFormat bool `json:"enableLogEntryFormat,omitempty"`
 }
 
 func (r LogExportRule) Validate() ValidationErrors {

--- a/web/static/docs/global-query/swagger.json
+++ b/web/static/docs/global-query/swagger.json
@@ -371,6 +371,9 @@
                 "pod": {
                     "type": "string"
                 },
+                "podUid": {
+                    "type": "string"
+                },
                 "sourcePath": {
                     "type": "string"
                 },
@@ -478,6 +481,10 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "enableLogEntryFormat": {
+                    "type": "boolean",
+                    "default": false
                 },
                 "end": {
                     "description": "End time for query",

--- a/web/static/docs/operator/swagger.json
+++ b/web/static/docs/operator/swagger.json
@@ -444,6 +444,10 @@
                     "description": "Description of this rule",
                     "type": "string"
                 },
+                "enableLogEntryFormat": {
+                    "description": "Enable structured messages to include chunk metadata",
+                    "type": "boolean"
+                },
                 "filter": {
                     "description": "Generate metrics from logs using target or log-based rules",
                     "allOf": [

--- a/web/static/docs/query/swagger.json
+++ b/web/static/docs/query/swagger.json
@@ -371,6 +371,9 @@
                 "pod": {
                     "type": "string"
                 },
+                "podUid": {
+                    "type": "string"
+                },
                 "sourcePath": {
                     "type": "string"
                 },
@@ -478,6 +481,10 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "enableLogEntryFormat": {
+                    "type": "boolean",
+                    "default": false
                 },
                 "end": {
                     "description": "End time for query",


### PR DESCRIPTION
Related: https://github.com/naver/lobster/issues/9

### Summary

- When logs are delivered to Kafka, metadata about the log source has not been included
- As the demand for log pipelines increases, it has become necessary to distinguish the log source

### Changes

- Enable the `enableLogEntryFormat: true` option to include pod metadata (such as cluster and labels) in the message
- Add support for a `time` field so that other log pipelines(such as Vector), can correctly recognize the log timestamp

- 
```
apiVersion: lobster.io/v1
kind: LobsterSink
metadata:
  name: test
  namespace: log-test
   spec:
     logExportRules:
     - enableLogEntryFormat: true
     ...
```

<img width="2342" height="1174" alt="screenshot" src="https://github.com/user-attachments/assets/e267119b-9a91-4d22-be7b-f7e0009d4b67" />