### PR TITLE
add logs to identify heavy requests

### DIFF
--- a/pkg/lobster/server/handler/log/list.go
+++ b/pkg/lobster/server/handler/log/list.go
@@ -60,6 +60,8 @@ func (h ListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	glog.Infof("ListHandler handling request: %s", req.String())
+
 	chunks, err := h.Querier.GetChunksWithinRange(req)
 	if err != nil {
 		glog.Error(err)

--- a/pkg/lobster/server/handler/log/range.go
+++ b/pkg/lobster/server/handler/log/range.go
@@ -62,6 +62,8 @@ func (h RangeHandler) ServeForStringContents(req query.Request, w http.ResponseW
 		return
 	}
 
+	glog.Infof("RangeHandler handling request: %s", req.String())
+
 	contents, _, _, numOfChunk, pageInfo, err := h.Querier.GetBlocksWithinRange(req)
 	if err != nil {
 		errors.HandleError(w, err)

--- a/pkg/lobster/server/handler/log/series.go
+++ b/pkg/lobster/server/handler/log/series.go
@@ -67,6 +67,8 @@ func (h SeriesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	glog.Infof("SeriesHandler handling request: %s", req.String())
+
 	numOfChunk, seriesData, err := h.Querier.GetSeriesInBlocksWithinRange(req)
 	if err != nil {
 		errors.HandleError(w, err)


### PR DESCRIPTION
Related: https://github.com/naver/lobster/issues/7

### Summary

- Record incoming requests to identify which requests trigger OOM events
- In the long term, analyze the characteristics of incoming requests and explore support strategies for cases where large-sized requests are present

e.g.
```
I0225 16:22:14.096693       1 series.go:70] SeriesHandler handling request: {"id":"759f9373-c5d1-46fd-8bef-e3c0505d8a0f","namespaces":["log-test"],"labels":[{"app":"loggen"}],"pod_uid":"aeae00be-fcf4-4c60-88ae-19089737d2ff","container":"loggen2","source":{"type":"stdstream","path":""},"start":"1772002319","end":"1772004119","page":1,"local":true}
I0225 16:22:14.101150       1 inspector.go:52] [10.105.68.74:34600] took 0.004614s /api/v2/logs/series 0 4050bytes
I0225 16:22:14.102605       1 series.go:70] SeriesHandler handling request: {"id":"759f9373-c5d1-46fd-8bef-e3c0505d8a0f","namespaces":["log-test"],"labels":[{"app":"loggen"}],"pod_uid":"aeae00be-fcf4-4c60-88ae-19089737d2ff","container":"loggen2","source":{"type":"stdstream","path":""},"start":"1772002319","end":"1772004119","page":1,"local":true}
I0225 16:22:14.107973       1 inspector.go:52] [10.105.68.74:34600] took 0.005452s /api/v2/logs/series 0 4050bytes
I0225 16:22:14.108588       1 range.go:65] RangeHandler handling request: {"id":"759f9373-c5d1-46fd-8bef-e3c0505d8a0f","namespaces":["log-test"],"labels":[{"app":"loggen"}],"pod_uid":"aeae00be-fcf4-4c60-88ae-19089737d2ff","container":"loggen2","source":{"type":"stdstream","path":""},"start":"1772002319","end":"1772004119","page":1,"local":true}
I0225 16:22:14.112445       1 inspector.go:52] [10.105.68.74:34600] took 0.003930s /api/v2/logs/range 0 9446bytes
```