### PR TITLE
add a safe lookback to include logs created during the stale period

### DIFF
--- a/pkg/lobster/sink/exporter/counter/receipt.go
+++ b/pkg/lobster/sink/exporter/counter/receipt.go
@@ -39,3 +39,11 @@ func (r *Receipt) Update(exportBytes int, exportTime time.Time, interval time.Du
 func (r Receipt) IsStale(t time.Time) bool {
 	return t.Sub(r.ExportTime).Seconds() > liveFactor*r.ExportInterval.Seconds()
 }
+
+func SafeLookback(interval, maxLookback time.Duration) time.Duration {
+	safeLookback := liveFactor * interval
+	if maxLookback < safeLookback {
+		return maxLookback
+	}
+	return safeLookback
+}

--- a/pkg/lobster/sink/exporter/counter/receipt_test.go
+++ b/pkg/lobster/sink/exporter/counter/receipt_test.go
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package counter
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSafeLookback(t *testing.T) {
+	tests := []struct {
+		name        string
+		interval    time.Duration
+		maxLookback time.Duration
+		expected    time.Duration
+	}{
+		{
+			name:        "liveFactor * interval is smaller than maxLookback",
+			interval:    10 * time.Minute,
+			maxLookback: time.Hour,
+			expected:    30 * time.Minute, // liveFactor(3) * 10min
+		},
+		{
+			name:        "maxLookback is smaller than liveFactor * interval",
+			interval:    30 * time.Minute,
+			maxLookback: time.Hour,
+			expected:    time.Hour, // maxLookback
+		},
+		{
+			name:        "equal values",
+			interval:    20 * time.Minute,
+			maxLookback: time.Hour,
+			expected:    time.Hour, // both are equal
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SafeLookback(tt.interval, tt.maxLookback)
+			if result != tt.expected {
+				t.Errorf("SafeLookback() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSafeLookbackCoversDelayedLogs(t *testing.T) {
+	interval := 10 * time.Minute
+	maxLookback := time.Hour
+	safeLookback := SafeLookback(interval, maxLookback)
+
+	current := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// Simulate initial receipt creation with SafeLookback
+	// ExportTime = current - interval (ensures isRightTimeToExport passes)
+	// LogTime = current - safeLookback (determines log query range)
+	initialReceiptExportTime := current.Add(-interval)
+	initialReceiptLogTime := current.Add(-safeLookback)
+
+	// Verify isRightTimeToExport() would pass for new receipt
+	// Logic: interval.Seconds() <= current.Sub(exportTime).Seconds()
+	timeSinceExport := current.Sub(initialReceiptExportTime)
+	if timeSinceExport < interval {
+		t.Errorf("isRightTimeToExport() would fail: timeSinceExport=%v < interval=%v", timeSinceExport, interval)
+	}
+
+	// Delayed logs that arrived now but have old timestamps
+	delayedLogs := []struct {
+		name         string
+		logTimestamp time.Time
+		shouldExport bool
+	}{
+		{
+			name:         "log from 5 minutes ago",
+			logTimestamp: current.Add(-5 * time.Minute),
+			shouldExport: true,
+		},
+		{
+			name:         "log from 15 minutes ago (outside interval, inside safeLookback)",
+			logTimestamp: current.Add(-15 * time.Minute),
+			shouldExport: true,
+		},
+		{
+			name:         "log from 25 minutes ago (outside interval, inside safeLookback)",
+			logTimestamp: current.Add(-25 * time.Minute),
+			shouldExport: true,
+		},
+		{
+			name:         "log from exactly safeLookback ago",
+			logTimestamp: current.Add(-safeLookback),
+			shouldExport: true,
+		},
+		{
+			name:         "log from beyond safeLookback",
+			logTimestamp: current.Add(-safeLookback - time.Second),
+			shouldExport: false,
+		},
+	}
+
+	for _, log := range delayedLogs {
+		t.Run(log.name, func(t *testing.T) {
+			// Check if log would be included in export range
+			inRange := !log.logTimestamp.Before(initialReceiptLogTime) && !log.logTimestamp.After(current)
+
+			if inRange != log.shouldExport {
+				t.Errorf("log export = %v, expected %v (logTimestamp: %v, initialLogTime: %v, safeLookback: %v)",
+					inRange, log.shouldExport, log.logTimestamp, initialReceiptLogTime, safeLookback)
+			}
+		})
+	}
+}

--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -202,7 +202,7 @@ func (e *LogExporter) export(current time.Time, uploader uploader.Uploader, orde
 		glog.Error(err)
 	}
 	if !ok {
-		receipt = e.counter.Produce(0, current.Add(-interval), interval, current.Add(-interval))
+		receipt = e.counter.Produce(0, current.Add(-interval), interval, current.Add(-counter.SafeLookback(interval, *conf.MaxLookback)))
 	}
 
 	defer func(key string, receipt *counter.Receipt) {


### PR DESCRIPTION
### Problem

- Logs may be written asynchronously, and their chronological order is not always preserved
- When the timestamp recorded in the log differs from the actual write time, the log may fall outside the query window used by the log exporter. As a result, such logs can be unintentionally excluded from the export results
- This issue becomes more visible when logs arrive with timestamps older than the current export interval
- This behavior is common in request-duration-based logs such as Istio access logs

### Root Cause

Lobster exports logs based on a fixed time window defined by the log export interval.
- query window: `{current - interval} ~ {current}`

However, some systems (e.g., Istio access logs) record the timestamp when the request is received rather than when the log entry is written. Because of this behavior, a discrepancy can occur between:
- `{request received time; log timestamp} != {actual write time}`

For example, consider the following log entry:

```
2026-01-15T23:14:43.634Z "POST ... 1383 ..."
```

The log indicates a duration of **1383 ms**, meaning the log was likely written around:

```
43.634s + 1383ms ≈ 45.017s (2026-01-15T23:14:45.017)
```

If the exporter queries logs during the following windows and  the log was skipped during transmission.

```
08:14:39 ~ 08:14:44  (export #1)  // The log line was not yet written (2026-01-15T23:14:45.017)
08:14:44 ~ 08:14:49  (export #2)  // It's timestamp does not fall within the query window (2026-01-15T23:14:43.634Z)
```

### Solution

To mitigate this issue, Lobster expands the lookback window when a tailer is introduced
- Instead of querying logs only within the export interval, the system queries a wider range to capture delayed logs
  - as-is: `{current - interval} ~ {current}`
  - to-be: `{current - interval * liveFactor} ~ {current}`
    - `liveFactor = 3`: a parameter used internally to manage stale checkpoints when no logs are received for an interval
- This expanded window allows logs with older timestamps that arrive late to still be included in the export
- This adjustment is only applied when the tailer is newly introduced. Applying the same logic during normal processing could cause duplicate transmissions
- Additional test cases are added to validate this behavior
