### PR TITLE
fix: skip non-regular files in LoadPodEmptyDir to prevent IO block

### DIFF
--- a/pkg/lobster/loader/loader.go
+++ b/pkg/lobster/loader/loader.go
@@ -140,6 +140,10 @@ func LoadPodEmptyDir(root string, podMap map[string]v1.Pod) []model.LogFile {
 		files := findLogFiles(empyDirPath)
 
 		for path, file := range files {
+			if !file.Mode().IsRegular() {
+				continue
+			}
+
 			logfile := model.LogFile{
 				Namespace: pod.Namespace,
 				Labels:    pod.Labels,


### PR DESCRIPTION
### Problem
- In `LoadPodEmptyDir`, files under the emptyDir volume are iterated without verifying whether they are regular files.
   As a result, attempting to read non-regular files (e.g., FIFO) can lead to indefinite blocking
- Files with a `.log` extension in emptyDir that are non-regular files are excluded from processing

### How to Reproduce
- Create a FIFO or a symbolic link without any writer inside an emptyDir volume
- Observe that the goroutine(pprof) blocks indefinitely when attempting to read the file

#### goroutine dump in fifo case 
```
prw-r--r--    1 user   user         0 Apr  9 10:41 test.log
```
```
goroutine 90 [syscall, 7 minutes]:
syscall.Syscall6(0x101, 0xffffffffffffff9c, 0xc0005e2c40, 0x80000, 0x0, 0x0, 0x0)
	/usr/local/go/src/syscall/syscall_linux.go:95 +0x39
syscall.openat(0xffffffffffffff9c, {0xc0005e2af0?, 0x47c3dc?}, 0x80000, 0x0)
	/usr/local/go/src/syscall/zsyscall_linux_amd64.go:98 +0x8e
syscall.Open(...)
	/usr/local/go/src/syscall/syscall_linux.go:284
os.open({0xc0005e2af0?, 0x520176?}, 0x11?, 0x523ec5?)
	/usr/local/go/src/os/file_open_unix.go:15 +0x2b
os.openFileNolog.func1(...)
	/usr/local/go/src/os/file_unix.go:279
os.ignoringEINTR(...)
	/usr/local/go/src/os/file_posix.go:251
os.openFileNolog({0xc0005e2af0, 0x6b}, 0x0, 0x0)
	/usr/local/go/src/os/file_unix.go:278 +0x94
os.OpenFile({0xc0005e2af0, 0x6b}, 0x0, 0x0)
	/usr/local/go/src/os/file.go:392 +0x3e
os.Open(...)
	/usr/local/go/src/os/file.go:370
github.com/naver/lobster/pkg/lobster/logline.HasProperLogLine({{0xc000047290, 0x14}, 0xc00500c300, {0xc000047260, 0x16}, {0xc0015393e0, 0x24}, {0x194447c, 0xc}, {0xc0005e2bc3, ...}, ...})
	/workspace/pkg/lobster/logline/parser.go:265 +0x46
github.com/naver/lobster/pkg/lobster/loader.LoadPodEmptyDir({0x7ffee0ae32a6, 0x15}, 0xc003d7f8e0?)
	/workspace/pkg/lobster/loader/loader.go:160 +0x49e
github.com/naver/lobster/pkg/lobster/distributor.(*Distributor).loadLogFiles(0xc00003dc40?, 0xc004199080)
	/workspace/pkg/lobster/distributor/distributor.go:169 +0x77
github.com/naver/lobster/pkg/lobster/distributor.(*Distributor).Run.func1(0xc0002b21c0)
	/workspace/pkg/lobster/distributor/distributor.go:93 +0x145
created by github.com/naver/lobster/pkg/lobster/distributor.(*Distributor).Run in goroutine 1
	/workspace/pkg/lobster/distributor/distributor.go:75 +0xb1
```

#### goroutine dump in symbolic link case 
```
lrwxrwxrwx    1 user   user        12 Apr  9 10:48 app.log -> /proc/1/fd/1
```
```
goroutine 97 [IO wait, 7 minutes]:
internal/poll.runtime_pollWait(0x7f83bf8d8a68, 0x72)
	/usr/local/go/src/runtime/netpoll.go:351 +0x85
internal/poll.(*pollDesc).wait(0xc002688fc0?, 0xc001878000?, 0x1)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x27
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/go/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Read(0xc002688fc0, {0xc001878000, 0x4000, 0x4000})
	/usr/local/go/src/internal/poll/fd_unix.go:165 +0x27a
os.(*File).read(...)
	/usr/local/go/src/os/file_posix.go:29
os.(*File).Read(0xc000a14048, {0xc001878000?, 0x1?, 0xc001700200?})
	/usr/local/go/src/os/file.go:124 +0x4f
bufio.(*Reader).fill(0xc0026885a0)
	/usr/local/go/src/bufio/bufio.go:113 +0x103
bufio.(*Reader).ReadSlice(0xc0026885a0, 0xa)
	/usr/local/go/src/bufio/bufio.go:380 +0x29
github.com/naver/lobster/pkg/lobster/logline.HasProperLogLine({{0xc000f87f98, 0x14}, 0xc000fef1a0, {0xc000f87f68, 0x16}, {0xc00126d200, 0x24}, {0x194447c, 0xc}, {0xc0008b8a03, ...}, ...})
	/workspace/pkg/lobster/logline/parser.go:283 +0x1c9
github.com/naver/lobster/pkg/lobster/loader.LoadPodEmptyDir({0x7fffcb44ce0c, 0x15}, 0xc001b378e0?)
	/workspace/pkg/lobster/loader/loader.go:160 +0x49e
github.com/naver/lobster/pkg/lobster/distributor.(*Distributor).loadLogFiles(0xc00032feb0?, 0xc000de0240)
	/workspace/pkg/lobster/distributor/distributor.go:169 +0x77
github.com/naver/lobster/pkg/lobster/distributor.(*Distributor).Run.func1(0xc000356070)
	/workspace/pkg/lobster/distributor/distributor.go:93 +0x145
created by github.com/naver/lobster/pkg/lobster/distributor.(*Distributor).Run in goroutine 1
	/workspace/pkg/lobster/distributor/distributor.go:75 +0xb1
```