### PR TITLE
Fix exporter error message

### DIFF
--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -19,6 +19,7 @@ package exporter
 import (
 	"context"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -127,7 +128,7 @@ func (e *LogExporter) Run(stopChan chan struct{}) {
 
 				exportedBytes, err := e.export(current, uploader, order, *chunk)
 				if err != nil {
-					glog.Errorf("%s : %v", err.Error(), order.Request)
+					glog.Errorf("%s : %v", strings.ReplaceAll(err.Error(), "\n", " "), order.Request)
 					metrics.AddSinkFailure(order.Request, order.SinkNamespace, order.SinkName, uploader.Type(), uploader.Name())
 				}
 

--- a/pkg/lobster/sink/exporter/exporter.go
+++ b/pkg/lobster/sink/exporter/exporter.go
@@ -128,7 +128,7 @@ func (e *LogExporter) Run(stopChan chan struct{}) {
 
 				exportedBytes, err := e.export(current, uploader, order, *chunk)
 				if err != nil {
-					glog.Errorf("%s : %v", strings.ReplaceAll(err.Error(), "\n", " "), order.Request)
+					glog.Errorf("%v | %s", order.Request, strings.ReplaceAll(err.Error(), "\n", " "))
 					metrics.AddSinkFailure(order.Request, order.SinkNamespace, order.SinkName, uploader.Type(), uploader.Name())
 				}
 

--- a/pkg/lobster/sink/exporter/uploader/kafka.go
+++ b/pkg/lobster/sink/exporter/uploader/kafka.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/IBM/sarama"
@@ -29,7 +30,6 @@ import (
 	"github.com/naver/lobster/pkg/lobster/sink/order"
 	"github.com/naver/lobster/pkg/lobster/util"
 	v1 "github.com/naver/lobster/pkg/operator/api/v1"
-	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -96,13 +96,7 @@ func (k KafkaUploader) Upload(data []byte, chunk model.Chunk, pStart, pEnd time.
 
 	if err := producer.SendMessages(newMessages(k.Order.LogExportRule.Kafka, data)); err != nil {
 		if producerErrors, ok := err.(sarama.ProducerErrors); ok {
-			newErr := errors.New("ProducerErrors")
-
-			for _, pe := range producerErrors {
-				newErr = errors.Wrap(newErr, pe.Err.Error())
-			}
-
-			return newErr
+			return formatProducerErrors(producerErrors)
 		}
 
 		return err
@@ -236,4 +230,17 @@ func newMessage(kafka *v1.Kafka, data []byte) *sarama.ProducerMessage {
 	}
 
 	return message
+}
+
+func formatProducerErrors(producerErrors sarama.ProducerErrors) error {
+	seen := make(map[string]struct{})
+	var uniqueErrs []string
+	for _, pe := range producerErrors {
+		msg := pe.Err.Error()
+		if _, ok := seen[msg]; !ok {
+			seen[msg] = struct{}{}
+			uniqueErrs = append(uniqueErrs, msg)
+		}
+	}
+	return fmt.Errorf("ProducerErrors(%d): %s", len(producerErrors), strings.Join(uniqueErrs, "; "))
 }

--- a/pkg/lobster/sink/exporter/uploader/kafka_test.go
+++ b/pkg/lobster/sink/exporter/uploader/kafka_test.go
@@ -1,0 +1,35 @@
+package uploader
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+func TestFormatProducerErrors(t *testing.T) {
+	pe := func(msgs ...string) sarama.ProducerErrors {
+		errs := make(sarama.ProducerErrors, len(msgs))
+		for i, m := range msgs {
+			errs[i] = &sarama.ProducerError{Err: errors.New(m)}
+		}
+		return errs
+	}
+
+	tests := []struct {
+		input sarama.ProducerErrors
+		want  string
+	}{
+		{pe("timeout"), "ProducerErrors(1): timeout"},
+		{pe("timeout", "timeout", "timeout"), "ProducerErrors(3): timeout"},
+		{pe("err A", "err B", "err C"), "ProducerErrors(3): err A; err B; err C"},
+		{pe("err A", "err B", "err A", "err B", "err A"), "ProducerErrors(5): err A; err B"},
+	}
+
+	for _, tt := range tests {
+		got := formatProducerErrors(tt.input).Error()
+		if got != tt.want {
+			t.Errorf("got %q, want %q", got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
### Summary
- Log export error messages were sometimes split across multiple lines or excessively long, making it difficult to identify the root cause
- This PR restructures log output so that both the error message and the request context are consistently represented within a single line

### Problem
- Error messages and request body were separated into different lines:

```
2026-04-21T16:31:48.872189247+09:00 stderr F E0421 16:31:48.872034       1 exporter.go:130] failed to upload file: SlowDown: Please reduce your request rate (throttled)
2026-04-21T16:31:48.872217469+09:00 stderr F 	status code: 429 ... : {"labels":[{"app":"istio"}], ...}
```

- Repeated broker error messages (e.g., circuit breaker) could dominate the log line:

```
// As a result, the request body or other important context could be truncated
2026-05-01T09:15:40.256444933+09:00 stderr F E0501 09:15:40.254753       1 exporter.go:130] circuit breaker is open: circuit breaker is open: circuit breaker is open: ....
```