### PR TITLE
add cluster field

### DIFF
--- a/pkg/lobster/sink/exporter/uploader/s3.go
+++ b/pkg/lobster/sink/exporter/uploader/s3.go
@@ -155,6 +155,7 @@ func (s S3Uploader) templateDir(chunk model.Chunk, date time.Time) (string, erro
 	return template.GeneratePath(
 		s.Order.LogExportRule.S3Bucket.PathTemplate,
 		template.PathElement{
+			Cluster:    chunk.Cluster,
 			Namespace:  chunk.Namespace,
 			SinkName:   s.Order.SinkName,
 			RuleName:   s.Order.LogExportRule.Name,


### PR DESCRIPTION
Support cluster template variable in S3 log export path templates.

#### Example

- Path template: `/access-log/{{TimeLayout "2006-01-02"}}/{{TimeLayout "15"}}/{{.Cluster}}/{{.Pod}}`
- Expected: `/access-log/2026-05-11/09/cluster-a/pod-a/2026-05-11T09:13:58+09:00_2026-05-11T09:18:58+09:00.log for ...`
- Current status: `/access-log/2026-05-11/09/pod-a/2026-05-11T09:13:58+09:00_2026-05-11T09:18:58+09:00.log for ...`(`cluster-a` is missing)