### PR TITLE
Release metrics of deleted pods

### DIFF
--- a/pkg/lobster/distributor/distributor.go
+++ b/pkg/lobster/distributor/distributor.go
@@ -30,14 +30,12 @@ import (
 	"github.com/naver/lobster/pkg/lobster/logline"
 	"github.com/naver/lobster/pkg/lobster/metrics"
 	"github.com/naver/lobster/pkg/lobster/model"
-	"github.com/naver/lobster/pkg/lobster/query"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/naver/lobster/pkg/lobster/sink/helper"
 	"github.com/naver/lobster/pkg/lobster/sink/matcher"
 	"github.com/naver/lobster/pkg/lobster/store"
 	"github.com/naver/lobster/pkg/lobster/tailer"
-	"github.com/naver/lobster/pkg/lobster/util"
 )
 
 var (
@@ -131,8 +129,7 @@ func (d *Distributor) Run(stopChan chan struct{}) {
 		for {
 			select {
 			case <-metricsTicker.C:
-				end := time.Now()
-				d.updateMetrics(end.Add(-*conf.MetricsInterval), end)
+				d.updateMetrics()
 			case <-stopChan:
 				glog.Info("stop metrics production")
 				return
@@ -323,13 +320,8 @@ func (d *Distributor) storeTailedLogs(file model.LogFile, chunk *model.Chunk, ke
 	}
 }
 
-func (d *Distributor) updateMetrics(start, end time.Time) {
-	chunks, _ := d.store.GetChunksWithinRange(query.Request{
-		Start: util.Timestamp{Time: start},
-		End:   util.Timestamp{Time: end},
-	})
-
-	for _, chunk := range chunks {
+func (d *Distributor) updateMetrics() {
+	for _, chunk := range d.store.GetChunks() {
 		metrics.SetSizeOfBlocksInChunk(chunk.Namespace, chunk.Pod, chunk.Container, chunk.Source.Type, chunk.Source.Path, float64(chunk.Size))
 	}
 

--- a/pkg/lobster/distributor/distributor.go
+++ b/pkg/lobster/distributor/distributor.go
@@ -88,7 +88,7 @@ func (d *Distributor) Run(stopChan chan struct{}) {
 					panic("no pods found")
 				}
 
-				d.updateLabelsInChunks(podMap)
+				d.updateChunksByPods(podMap)
 
 				logfiles, err := d.loadLogFiles(podMap)
 				if err != nil {
@@ -141,9 +141,11 @@ func (d *Distributor) Run(stopChan chan struct{}) {
 	}(stopChan)
 }
 
-func (d *Distributor) updateLabelsInChunks(podMap map[string]v1.Pod) {
+func (d *Distributor) updateChunksByPods(podMap map[string]v1.Pod) {
 	d.store.UpdateChunks(func(chunk *model.Chunk) {
 		pod, ok := podMap[chunk.PodUid]
+
+		chunk.PodDeleted = !ok
 
 		if !ok {
 			return

--- a/pkg/lobster/distributor/distributor.go
+++ b/pkg/lobster/distributor/distributor.go
@@ -321,9 +321,18 @@ func (d *Distributor) storeTailedLogs(file model.LogFile, chunk *model.Chunk, ke
 }
 
 func (d *Distributor) updateMetrics() {
+	staleSize := float64(0)
+
 	for _, chunk := range d.store.GetChunks() {
+		if chunk.PodDeleted {
+			staleSize = staleSize + float64(chunk.Size)
+			continue
+		}
+
 		metrics.SetSizeOfBlocksInChunk(chunk.Namespace, chunk.Pod, chunk.Container, chunk.Source.Type, chunk.Source.Path, float64(chunk.Size))
 	}
+
+	metrics.SetSizeOfStaleBlocks(staleSize)
 
 	limits := d.store.GetLimits()
 	for _, limit := range limits {

--- a/pkg/lobster/distributor/metrics_test.go
+++ b/pkg/lobster/distributor/metrics_test.go
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package distributor
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/naver/lobster/pkg/lobster/metrics"
+	"github.com/naver/lobster/pkg/lobster/model"
+	"github.com/naver/lobster/pkg/lobster/store"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var registerStoreMetricsOnce sync.Once
+
+// hasBlockSeries reports whether a pod holds a lobster_blocks series on the default registry,
+// which is what /metrics scrapes.
+func hasBlockSeries(t *testing.T, pod string) bool {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != "lobster_blocks" {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "log_pod" && label.GetValue() == pod {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func staleBlocks(t *testing.T) float64 {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	for _, family := range families {
+		if family.GetName() != "lobster_stale_blocks" {
+			continue
+		}
+		if len(family.GetMetric()) != 1 {
+			t.Fatalf("lobster_stale_blocks: expected exactly 1 series, got %d", len(family.GetMetric()))
+		}
+		if labels := family.GetMetric()[0].GetLabel(); len(labels) != 0 {
+			t.Fatalf("lobster_stale_blocks: expected no labels, got %d", len(labels))
+		}
+
+		return family.GetMetric()[0].GetGauge().GetValue()
+	}
+
+	t.Fatal("lobster_stale_blocks: series not found")
+
+	return 0
+}
+
+func newMetricsTestChunk(pod string, size int64, podDeleted bool) *model.Chunk {
+	return &model.Chunk{
+		Id:         pod,
+		Namespace:  "ns-a",
+		Pod:        pod,
+		PodUid:     "uid-" + pod,
+		Container:  "container-a",
+		Source:     model.Source{Type: model.LogTypeStdStream},
+		TempBlock:  &model.TempBlock{Size: size},
+		UpdatedAt:  time.Now(),
+		StartedAt:  time.Now(),
+		Size:       size,
+		PodDeleted: podDeleted,
+	}
+}
+
+func newMetricsTestDistributor(t *testing.T, chunks ...*model.Chunk) Distributor {
+	t.Helper()
+	registerStoreMetricsOnce.Do(metrics.RegisterStoreMetrics)
+
+	s, err := store.NewStore()
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+
+	for _, chunk := range chunks {
+		s.StoreChunk(chunk.Source, chunk.PodUid, chunk.Container, chunk)
+	}
+
+	return Distributor{store: s}
+}
+
+// A chunk whose pod is gone keeps its blocks until retention expires, but the store releases
+// its per-chunk series as soon as the pod disappears. Re-setting it here would resurrect a
+// series nothing cleans up again, so the size is folded into the unlabeled aggregate instead.
+func TestUpdateMetricsFoldsDeletedPodsIntoStaleBlocks(t *testing.T) {
+	d := newMetricsTestDistributor(t,
+		newMetricsTestChunk("pod-live", 100, false),
+		newMetricsTestChunk("pod-gone", 300, true),
+		newMetricsTestChunk("pod-gone-too", 700, true),
+	)
+
+	d.updateMetrics()
+
+	if !hasBlockSeries(t, "pod-live") {
+		t.Error("lobster_blocks: expected the live pod to keep its series")
+	}
+	for _, pod := range []string{"pod-gone", "pod-gone-too"} {
+		if hasBlockSeries(t, pod) {
+			t.Errorf("lobster_blocks: expected no series for deleted pod %s", pod)
+		}
+	}
+
+	if got := staleBlocks(t); got != 1000 {
+		t.Errorf("lobster_stale_blocks: expected 1000, got %v", got)
+	}
+}
+
+// The aggregate is rewritten every round, so once the deleted pods age out it must fall back
+// to zero rather than keeping the last total.
+func TestUpdateMetricsReportsZeroStaleBlocks(t *testing.T) {
+	d := newMetricsTestDistributor(t, newMetricsTestChunk("pod-only-live", 100, false))
+
+	d.updateMetrics()
+
+	if got := staleBlocks(t); got != 0 {
+		t.Errorf("lobster_stale_blocks: expected 0, got %v", got)
+	}
+}

--- a/pkg/lobster/metrics/expiring_metric.go
+++ b/pkg/lobster/metrics/expiring_metric.go
@@ -17,6 +17,7 @@
 package metrics
 
 import (
+	"sort"
 	"strings"
 	"time"
 
@@ -69,13 +70,15 @@ func (e expiringMetric) refresh(labels prometheus.Labels) {
 }
 
 func (e expiringMetric) key(labels prometheus.Labels) string {
-	values := []string{}
+	pairs := make([]string, 0, len(labels))
 
-	for _, value := range labels {
-		values = append(values, string(value))
+	for name, value := range labels {
+		pairs = append(pairs, name+"="+value)
 	}
 
-	return strings.Join(values, "")
+	sort.Strings(pairs)
+
+	return strings.Join(pairs, ",")
 }
 
 func (e *expiringMetric) ClearStaleMetrics() {

--- a/pkg/lobster/metrics/expiring_metric_test.go
+++ b/pkg/lobster/metrics/expiring_metric_test.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/naver/lobster/pkg/lobster/query"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func testExporterLabels(pod string) prometheus.Labels {
+	return exporterLabelValues(
+		query.Request{
+			Namespace: testNamespace,
+			Pod:       pod,
+			Container: testContainer,
+		},
+		"sink-ns", "sink-a", "s3", "rule-a")
+}
+
+func newTestExpiringMetric() expiringMetric {
+	return newExpiringMetricVector(prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "lobster_expiring_metric_test_total",
+		Help: "A counter used to exercise expiringMetric.",
+	}, exporterKeys))
+}
+
+func expire(e expiringMetric) {
+	for key, hist := range e.historyMap {
+		hist.occurred = time.Now().Add(-2 * e.expiration)
+		e.historyMap[key] = hist
+	}
+}
+
+// Go randomizes map iteration order, so a key built by walking the label map must still come
+// out identical every time. When it did not, one label set scattered across several history
+// entries and stale ones expired series that were still live.
+func TestExpiringMetricKeyIsStable(t *testing.T) {
+	e := newTestExpiringMetric()
+	labels := testExporterLabels(testPod)
+
+	first := e.key(labels)
+
+	for i := 0; i < 500; i++ {
+		if got := e.key(labels); got != first {
+			t.Fatalf("key is unstable: %q != %q", got, first)
+		}
+	}
+}
+
+// Joining bare values would let two different label sets collide whenever the same values are
+// spread across different labels.
+func TestExpiringMetricKeyDistinguishesSwappedValues(t *testing.T) {
+	e := newTestExpiringMetric()
+
+	a := prometheus.Labels{labelLogPod: "x", labelLogContainer: "y"}
+	b := prometheus.Labels{labelLogPod: "y", labelLogContainer: "x"}
+
+	if e.key(a) == e.key(b) {
+		t.Errorf("expected distinct keys for swapped values, both are %q", e.key(a))
+	}
+}
+
+func TestExpiringMetricRefreshKeepsOneEntryPerLabelSet(t *testing.T) {
+	e := newTestExpiringMetric()
+	labels := testExporterLabels(testPod)
+
+	for i := 0; i < 500; i++ {
+		e.Add(labels, 1)
+	}
+
+	if len(e.historyMap) != 1 {
+		t.Errorf("expected 1 history entry for a single label set, got %d", len(e.historyMap))
+	}
+	if count := collectAndCount(e.CounterVec); count != 1 {
+		t.Errorf("expected 1 series, got %d", count)
+	}
+}
+
+// A series that keeps being updated must survive, no matter how often it is written.
+func TestClearStaleMetricsKeepsRefreshedSeries(t *testing.T) {
+	e := newTestExpiringMetric()
+	labels := testExporterLabels(testPod)
+
+	for i := 0; i < 100; i++ {
+		e.Add(labels, 1)
+	}
+
+	e.ClearStaleMetrics()
+
+	if count := collectAndCount(e.CounterVec); count != 1 {
+		t.Errorf("expected the refreshed series to survive, got %d series", count)
+	}
+}
+
+func TestClearStaleMetricsRemovesExpiredSeries(t *testing.T) {
+	e := newTestExpiringMetric()
+
+	e.Add(testExporterLabels("pod-stale"), 1)
+	expire(e)
+	e.Add(testExporterLabels("pod-live"), 1)
+
+	if count := collectAndCount(e.CounterVec); count != 2 {
+		t.Fatalf("expected 2 series before clearing, got %d", count)
+	}
+
+	e.ClearStaleMetrics()
+
+	if count := collectAndCount(e.CounterVec); count != 1 {
+		t.Errorf("expected only the live series to remain, got %d", count)
+	}
+	if len(e.historyMap) != 1 {
+		t.Errorf("expected the expired history entry to be dropped, got %d", len(e.historyMap))
+	}
+}
+
+// A nil vector is the zero value of the struct; the helpers must stay inert rather than panic.
+func TestExpiringMetricIgnoresNilVector(t *testing.T) {
+	e := newExpiringMetricVector(nil)
+
+	e.Inc(testExporterLabels(testPod))
+	e.Add(testExporterLabels(testPod), 1)
+
+	if len(e.historyMap) != 0 {
+		t.Errorf("expected no history to be recorded, got %d entries", len(e.historyMap))
+	}
+}

--- a/pkg/lobster/metrics/store.go
+++ b/pkg/lobster/metrics/store.go
@@ -29,6 +29,11 @@ var (
 		Help: "A blocks total.",
 	}, chunkKeys)
 
+	staleBlockTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "lobster_stale_blocks",
+		Help: "A blocks total of chunks whose pod no longer exists.",
+	}, []string{})
+
 	tailedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "lobster_tailed_bytes_total",
 		Help: "A bytes of lines tailed.",
@@ -77,6 +82,7 @@ var (
 
 func RegisterStoreMetrics() {
 	prometheus.MustRegister(blockTotal)
+	prometheus.MustRegister(staleBlockTotal)
 	prometheus.MustRegister(tailedBytes)
 	prometheus.MustRegister(tailedLines)
 	prometheus.MustRegister(overloaded)
@@ -105,6 +111,10 @@ func emptyChunkLabelValues() prometheus.Labels {
 
 func SetSizeOfBlocksInChunk(namespace, pod, container, sourceType, sourcePath string, size float64) {
 	blockTotal.With(chunkLabelValues(namespace, pod, container, sourceType, sourcePath)).Set(size)
+}
+
+func SetSizeOfStaleBlocks(size float64) {
+	staleBlockTotal.WithLabelValues().Set(size)
 }
 
 func AddTailedBytes(namespace, pod, container, sourceType, sourcePath string, bytesLength float64) {

--- a/pkg/lobster/metrics/store.go
+++ b/pkg/lobster/metrics/store.go
@@ -21,25 +21,28 @@ import (
 )
 
 var (
+	chunkKeys          = promLabelsKeys(emptyChunkLabelValues())
+	chunkKeysWithLimit = append(promLabelsKeys(emptyChunkLabelValues()), labelLimit)
+
 	blockTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "lobster_blocks",
 		Help: "A blocks total.",
-	}, []string{labelTargetNamespace, labelLogPod, labelLogContainer, labelLogSourceType, labelLogSourcePath})
+	}, chunkKeys)
 
 	tailedBytes = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "lobster_tailed_bytes_total",
 		Help: "A bytes of lines tailed.",
-	}, []string{labelTargetNamespace, labelLogPod, labelLogContainer, labelLogSourceType, labelLogSourcePath})
+	}, chunkKeys)
 
 	tailedLines = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "lobster_tailed_lines_total",
 		Help: "A number of lines tailed.",
-	}, []string{labelTargetNamespace, labelLogPod, labelLogContainer, labelLogSourceType, labelLogSourcePath})
+	}, chunkKeys)
 
 	overloaded = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "lobster_overloaded_target_total",
 		Help: "A Number of stoping due to overloaded logs.",
-	}, []string{labelTargetNamespace, labelLogPod, labelLogContainer, labelLogSourceType, labelLogSourcePath, labelLimit})
+	}, chunkKeysWithLimit)
 
 	pushError = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "lobster_push_errors_total",
@@ -85,20 +88,38 @@ func RegisterStoreMetrics() {
 	prometheus.MustRegister(rootDiskLimit)
 }
 
+func chunkLabelValues(namespace, pod, container, sourceType, sourcePath string) prometheus.Labels {
+	return prometheus.Labels{
+		labelTargetNamespace: namespace,
+		labelLogNamespace:    namespace,
+		labelLogPod:          pod,
+		labelLogContainer:    container,
+		labelLogSourceType:   sourceType,
+		labelLogSourcePath:   sourcePath,
+	}
+}
+
+func emptyChunkLabelValues() prometheus.Labels {
+	return chunkLabelValues("", "", "", "", "")
+}
+
 func SetSizeOfBlocksInChunk(namespace, pod, container, sourceType, sourcePath string, size float64) {
-	blockTotal.WithLabelValues(namespace, pod, container, sourceType, sourcePath).Set(size)
+	blockTotal.With(chunkLabelValues(namespace, pod, container, sourceType, sourcePath)).Set(size)
 }
 
 func AddTailedBytes(namespace, pod, container, sourceType, sourcePath string, bytesLength float64) {
-	tailedBytes.WithLabelValues(namespace, pod, container, sourceType, sourcePath).Add(bytesLength)
+	tailedBytes.With(chunkLabelValues(namespace, pod, container, sourceType, sourcePath)).Add(bytesLength)
 }
 
 func AddTailedLines(namespace, pod, container, sourceType, sourcePath string, lines float64) {
-	tailedLines.WithLabelValues(namespace, pod, container, sourceType, sourcePath).Add(lines)
+	tailedLines.With(chunkLabelValues(namespace, pod, container, sourceType, sourcePath)).Add(lines)
 }
 
 func AddOverloadedCount(namespace, pod, container, sourceType, sourcePath, limit string) {
-	overloaded.WithLabelValues(namespace, pod, container, sourceType, sourcePath, limit).Add(1)
+	labels := chunkLabelValues(namespace, pod, container, sourceType, sourcePath)
+	labels[labelLimit] = limit
+
+	overloaded.With(labels).Add(1)
 }
 
 func AddPushError() {
@@ -133,16 +154,9 @@ func Delete(namespace, pod, container, sourceType, sourcePath string) {
 		labelLogSourceType: sourceType,
 		labelLogSourcePath: sourcePath,
 	}
-	blockTotal.Delete(labelChunk)
-	tailedBytes.Delete(labelChunk)
-	tailedLines.Delete(labelChunk)
+	blockTotal.DeletePartialMatch(labelChunk)
+	tailedBytes.DeletePartialMatch(labelChunk)
+	tailedLines.DeletePartialMatch(labelChunk)
 	overloaded.DeletePartialMatch(labelChunk)
-	flushSeconds.Delete(labelChunk)
-
-	labelNamespace := prometheus.Labels{
-		labelLogNamespace: namespace,
-	}
-	handleSeconds.Delete(labelNamespace)
-	responseBytes.Delete(labelNamespace)
-	responseCodes.Delete(labelNamespace)
+	flushSeconds.DeletePartialMatch(labelChunk)
 }

--- a/pkg/lobster/metrics/store_test.go
+++ b/pkg/lobster/metrics/store_test.go
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// collectAndCount returns the number of series currently held by a collector.
+//
+// client_golang's own prometheus/testutil is unusable here: its promlint dependency
+// still references expfmt.FmtText, which prometheus/common v0.48.0 removed.
+func collectAndCount(c prometheus.Collector) int {
+	ch := make(chan prometheus.Metric, 1024)
+
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+
+	count := 0
+	for range ch {
+		count++
+	}
+
+	return count
+}
+
+const (
+	testNamespace   = "ns-a"
+	testPod         = "pod-a"
+	testContainer   = "container-a"
+	testSourceType  = "stdstream"
+	testSourcePath  = ""
+	testHandlerPath = "/api/v1/logs/range"
+)
+
+func resetStoreMetrics() {
+	blockTotal.Reset()
+	tailedBytes.Reset()
+	tailedLines.Reset()
+	overloaded.Reset()
+	flushSeconds.Reset()
+	handleSeconds.Reset()
+	responseBytes.Reset()
+	responseCodes.Reset()
+}
+
+func addChunkMetrics(namespace, pod, container, sourceType, sourcePath string) {
+	SetSizeOfBlocksInChunk(namespace, pod, container, sourceType, sourcePath, 1)
+	AddTailedBytes(namespace, pod, container, sourceType, sourcePath, 1)
+	AddTailedLines(namespace, pod, container, sourceType, sourcePath, 1)
+	AddOverloadedCount(namespace, pod, container, sourceType, sourcePath, "1MB/s")
+	ObserveFlushSeconds(namespace, pod, container, sourceType, sourcePath, 0.1)
+}
+
+// A collection metric is attributed to labelTargetNamespace and matched by labelLogNamespace,
+// and both hold the namespace of the container the logs came from.
+func TestChunkLabelValuesFillBothNamespaces(t *testing.T) {
+	labels := chunkLabelValues(testNamespace, testPod, testContainer, testSourceType, testSourcePath)
+
+	for _, label := range []string{labelTargetNamespace, labelLogNamespace} {
+		if labels[label] != testNamespace {
+			t.Errorf("expected %s=%q, got %q", label, testNamespace, labels[label])
+		}
+	}
+}
+
+// Deletion must not depend on labelTargetNamespace, which is free to diverge from the log namespace.
+// Building the series with the full label set also pins the label names the vector declares,
+// since prometheus panics on a mismatch.
+func TestDeleteIgnoresTargetNamespace(t *testing.T) {
+	resetStoreMetrics()
+	defer resetStoreMetrics()
+
+	tailedLines.With(prometheus.Labels{
+		labelTargetNamespace: "sink-ns",
+		labelLogNamespace:    testNamespace,
+		labelLogPod:          testPod,
+		labelLogContainer:    testContainer,
+		labelLogSourceType:   testSourceType,
+		labelLogSourcePath:   testSourcePath,
+	}).Add(1)
+
+	if count := collectAndCount(tailedLines); count != 1 {
+		t.Fatalf("lobster_tailed_lines_total: expected 1 series before delete, got %d", count)
+	}
+
+	Delete(testNamespace, testPod, testContainer, testSourceType, testSourcePath)
+
+	if count := collectAndCount(tailedLines); count != 0 {
+		t.Errorf("lobster_tailed_lines_total: expected 0 series after delete, got %d", count)
+	}
+}
+
+func TestDeleteRemovesChunkKeyedSeries(t *testing.T) {
+	resetStoreMetrics()
+	defer resetStoreMetrics()
+
+	addChunkMetrics(testNamespace, testPod, testContainer, testSourceType, testSourcePath)
+
+	before := map[string]int{
+		"lobster_blocks":                  collectAndCount(blockTotal),
+		"lobster_tailed_bytes_total":      collectAndCount(tailedBytes),
+		"lobster_tailed_lines_total":      collectAndCount(tailedLines),
+		"lobster_overloaded_target_total": collectAndCount(overloaded),
+		"lobster_flush_seconds":           collectAndCount(flushSeconds),
+	}
+	for name, count := range before {
+		if count != 1 {
+			t.Fatalf("%s: expected 1 series before delete, got %d", name, count)
+		}
+	}
+
+	Delete(testNamespace, testPod, testContainer, testSourceType, testSourcePath)
+
+	after := map[string]int{
+		"lobster_blocks":                  collectAndCount(blockTotal),
+		"lobster_tailed_bytes_total":      collectAndCount(tailedBytes),
+		"lobster_tailed_lines_total":      collectAndCount(tailedLines),
+		"lobster_overloaded_target_total": collectAndCount(overloaded),
+		"lobster_flush_seconds":           collectAndCount(flushSeconds),
+	}
+	for name, count := range after {
+		if count != 0 {
+			t.Errorf("%s: expected 0 series after delete, got %d", name, count)
+		}
+	}
+}
+
+func TestDeleteKeepsMiddlewareSeries(t *testing.T) {
+	resetStoreMetrics()
+	defer resetStoreMetrics()
+
+	ObserveHandleSeconds(testHandlerPath, 0.1)
+	AddResponseBytes(testHandlerPath, 100)
+	AddResponseStatus(testHandlerPath, 200)
+
+	Delete(testNamespace, testPod, testContainer, testSourceType, testSourcePath)
+
+	// Middleware metrics are keyed by handler path and carry no chunk dimension,
+	// so a chunk deletion must never touch them.
+	for name, count := range map[string]int{
+		"lobster_handle_seconds":       collectAndCount(handleSeconds),
+		"lobster_response_bytes_total": collectAndCount(responseBytes),
+		"lobster_http_response_total":  collectAndCount(responseCodes),
+	} {
+		if count != 1 {
+			t.Errorf("%s: expected 1 series to survive, got %d", name, count)
+		}
+	}
+}
+
+func TestDeleteOnlyMatchingChunk(t *testing.T) {
+	resetStoreMetrics()
+	defer resetStoreMetrics()
+
+	// Two overloaded series for the target chunk, distinguished by the limit label.
+	AddOverloadedCount(testNamespace, testPod, testContainer, testSourceType, testSourcePath, "1MB/s")
+	AddOverloadedCount(testNamespace, testPod, testContainer, testSourceType, testSourcePath, "10MB/s")
+	// One series that must survive.
+	addChunkMetrics("ns-b", "pod-b", "container-b", testSourceType, testSourcePath)
+
+	if count := collectAndCount(overloaded); count != 3 {
+		t.Fatalf("lobster_overloaded_target_total: expected 3 series before delete, got %d", count)
+	}
+
+	Delete(testNamespace, testPod, testContainer, testSourceType, testSourcePath)
+
+	if count := collectAndCount(overloaded); count != 1 {
+		t.Errorf("lobster_overloaded_target_total: expected 1 surviving series, got %d", count)
+	}
+	for name, count := range map[string]int{
+		"lobster_blocks":             collectAndCount(blockTotal),
+		"lobster_tailed_bytes_total": collectAndCount(tailedBytes),
+		"lobster_tailed_lines_total": collectAndCount(tailedLines),
+		"lobster_flush_seconds":      collectAndCount(flushSeconds),
+	} {
+		if count != 1 {
+			t.Errorf("%s: expected the other chunk's series to survive, got %d", name, count)
+		}
+	}
+}

--- a/pkg/lobster/metrics/store_test.go
+++ b/pkg/lobster/metrics/store_test.go
@@ -53,6 +53,7 @@ const (
 
 func resetStoreMetrics() {
 	blockTotal.Reset()
+	staleBlockTotal.Reset()
 	tailedBytes.Reset()
 	tailedLines.Reset()
 	overloaded.Reset()
@@ -195,5 +196,42 @@ func TestDeleteOnlyMatchingChunk(t *testing.T) {
 		if count != 1 {
 			t.Errorf("%s: expected the other chunk's series to survive, got %d", name, count)
 		}
+	}
+}
+
+// lobster_stale_blocks stands in for the per-chunk series of pods that are gone, so it must
+// carry no chunk dimension at all and must not be swept up by a chunk deletion.
+func TestStaleBlocksIsUnlabeledAndSurvivesDelete(t *testing.T) {
+	resetStoreMetrics()
+	defer resetStoreMetrics()
+
+	addChunkMetrics(testNamespace, testPod, testContainer, testSourceType, testSourcePath)
+	SetSizeOfStaleBlocks(4096)
+
+	if count := collectAndCount(staleBlockTotal); count != 1 {
+		t.Fatalf("lobster_stale_blocks: expected 1 series, got %d", count)
+	}
+
+	Delete(testNamespace, testPod, testContainer, testSourceType, testSourcePath)
+
+	if count := collectAndCount(blockTotal); count != 0 {
+		t.Errorf("lobster_blocks: expected 0 series after delete, got %d", count)
+	}
+	if count := collectAndCount(staleBlockTotal); count != 1 {
+		t.Errorf("lobster_stale_blocks: expected the aggregate to survive, got %d series", count)
+	}
+}
+
+// The aggregate is a gauge that is rewritten every round, so reporting zero must keep the
+// series present rather than leaving the previous total behind.
+func TestStaleBlocksKeepsSeriesAtZero(t *testing.T) {
+	resetStoreMetrics()
+	defer resetStoreMetrics()
+
+	SetSizeOfStaleBlocks(4096)
+	SetSizeOfStaleBlocks(0)
+
+	if count := collectAndCount(staleBlockTotal); count != 1 {
+		t.Errorf("lobster_stale_blocks: expected the series to stay at zero, got %d", count)
 	}
 }

--- a/pkg/lobster/model/chunk.go
+++ b/pkg/lobster/model/chunk.go
@@ -46,6 +46,8 @@ type Chunk struct {
 	UpdatedAt           time.Time   `json:"updatedAt"`
 	DeletionMark        bool        `json:"-"`
 	DeletionMarkInBlock bool        `json:"-"`
+	PodDeleted          bool        `json:"-"`
+	MetricsCleared      bool        `json:"-"`
 	Line                int64       `json:"line" format:"int64"`
 	Size                int64       `json:"size" format:"int64"`
 	CheckPoint          *CheckPoint `json:"-"`

--- a/pkg/lobster/store/metric_cleaner.go
+++ b/pkg/lobster/store/metric_cleaner.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package store
+
+import (
+	"github.com/golang/glog"
+	"github.com/naver/lobster/pkg/lobster/metrics"
+	"github.com/naver/lobster/pkg/lobster/model"
+)
+
+type metricKey struct {
+	namespace  string
+	pod        string
+	container  string
+	sourceType string
+	sourcePath string
+}
+
+func chunkMetricKey(chunk *model.Chunk) metricKey {
+	return metricKey{
+		namespace:  chunk.Namespace,
+		pod:        chunk.Pod,
+		container:  chunk.Container,
+		sourceType: chunk.Source.Type,
+		sourcePath: chunk.Source.Path,
+	}
+}
+
+func (s *Store) cleanMetrics() {
+	live := map[metricKey]bool{}
+	deleted := []*model.Chunk{}
+
+	s.chunkCache.Range(func(_, value any) bool {
+		chunk := value.(*model.Chunk)
+
+		if chunk.PodDeleted {
+			deleted = append(deleted, chunk)
+		} else {
+			live[chunkMetricKey(chunk)] = true
+			chunk.MetricsCleared = false
+		}
+
+		return true
+	})
+
+	for _, chunk := range deleted {
+		if chunk.MetricsCleared || live[chunkMetricKey(chunk)] {
+			continue
+		}
+
+		metrics.Delete(chunk.Namespace, chunk.Pod, chunk.Container, chunk.Source.Type, chunk.Source.Path)
+		chunk.MetricsCleared = true
+		glog.V(3).Infof("clear metrics of deleted pod : %s\n", chunk.Id)
+	}
+}

--- a/pkg/lobster/store/metric_cleaner.go
+++ b/pkg/lobster/store/metric_cleaner.go
@@ -63,6 +63,7 @@ func (s *Store) cleanMetrics() {
 		}
 
 		metrics.Delete(chunk.Namespace, chunk.Pod, chunk.Container, chunk.Source.Type, chunk.Source.Path)
+		metrics.DeleteMatchedLogs(chunk.Namespace, chunk.Pod, chunk.Container, chunk.Source.Type, chunk.Source.Path)
 		chunk.MetricsCleared = true
 		glog.V(3).Infof("clear metrics of deleted pod : %s\n", chunk.Id)
 	}

--- a/pkg/lobster/store/metric_cleaner_test.go
+++ b/pkg/lobster/store/metric_cleaner_test.go
@@ -20,12 +20,46 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/naver/lobster/pkg/lobster/metrics"
 	"github.com/naver/lobster/pkg/lobster/model"
+	"github.com/naver/lobster/pkg/lobster/query"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Chunk.MetricsCleared flips exactly when metrics.Delete is called, so these tests assert on the
 // flag instead of reaching into the metrics package.
 // The deletion itself is covered by pkg/lobster/metrics/store_test.go.
+
+var registerMatcherMetricsOnce sync.Once
+
+// countSeries reads the default registry, which is what /metrics scrapes, and counts the
+// series of one metric family belonging to a single pod.
+func countSeries(t *testing.T, familyName, pod string) int {
+	t.Helper()
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+
+	count := 0
+
+	for _, family := range families {
+		if family.GetName() != familyName {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "log_pod" && label.GetValue() == pod {
+					count++
+				}
+			}
+		}
+	}
+
+	return count
+}
 
 func newTestStore() *Store {
 	return &Store{chunkCache: sync.Map{}}
@@ -136,5 +170,61 @@ func TestCleanMetricsClearsDeletedPodOfDistinctName(t *testing.T) {
 	}
 	if alive.MetricsCleared {
 		t.Error("expected metrics of the existing pod to be kept")
+	}
+}
+
+// cleanMetrics releases every series keyed by the chunk, not just the ones behind
+// metrics.Delete. Matched-log series carry the same pod label and used to be released only by
+// retention, so they outlived the pod by up to store.retentionTime.
+func TestCleanMetricsClearsMatchedLogsOfDeletedPod(t *testing.T) {
+	registerMatcherMetricsOnce.Do(metrics.RegisterMatcherMetrics)
+
+	s := newTestStore()
+	chunk := newTestChunk("pod-matched", "uid-matched", true)
+	s.storeTestChunk(chunk)
+
+	req := query.Request{
+		Namespace: chunk.Namespace,
+		Pod:       chunk.Pod,
+		Container: chunk.Container,
+		Source:    chunk.Source,
+	}
+	metrics.AddMatchedLogs(req, "sink-ns", "sink-a", "rule-a")
+	metrics.AddMatchedLogsError(req, "sink-ns", "sink-a", "rule-a")
+
+	if count := countSeries(t, "lobster_log_metric_matched_logs_total", chunk.Pod); count != 1 {
+		t.Fatalf("expected 1 matched-logs series before cleaning, got %d", count)
+	}
+
+	s.cleanMetrics()
+
+	for _, name := range []string{
+		"lobster_log_metric_matched_logs_total",
+		"lobster_log_metric_matched_logs_error_total",
+	} {
+		if count := countSeries(t, name, chunk.Pod); count != 0 {
+			t.Errorf("%s: expected the deleted pod's series to be released, got %d", name, count)
+		}
+	}
+}
+
+func TestCleanMetricsKeepsMatchedLogsOfExistingPod(t *testing.T) {
+	registerMatcherMetricsOnce.Do(metrics.RegisterMatcherMetrics)
+
+	s := newTestStore()
+	chunk := newTestChunk("pod-matched-live", "uid-matched-live", false)
+	s.storeTestChunk(chunk)
+
+	metrics.AddMatchedLogs(query.Request{
+		Namespace: chunk.Namespace,
+		Pod:       chunk.Pod,
+		Container: chunk.Container,
+		Source:    chunk.Source,
+	}, "sink-ns", "sink-a", "rule-a")
+
+	s.cleanMetrics()
+
+	if count := countSeries(t, "lobster_log_metric_matched_logs_total", chunk.Pod); count != 1 {
+		t.Errorf("expected the live pod's series to survive, got %d", count)
 	}
 }

--- a/pkg/lobster/store/metric_cleaner_test.go
+++ b/pkg/lobster/store/metric_cleaner_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package store
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/naver/lobster/pkg/lobster/model"
+)
+
+// Chunk.MetricsCleared flips exactly when metrics.Delete is called, so these tests assert on the
+// flag instead of reaching into the metrics package.
+// The deletion itself is covered by pkg/lobster/metrics/store_test.go.
+
+func newTestStore() *Store {
+	return &Store{chunkCache: sync.Map{}}
+}
+
+func newTestChunk(pod, podUid string, podDeleted bool) *model.Chunk {
+	return &model.Chunk{
+		Id:         pod + "_" + podUid,
+		Namespace:  "ns-a",
+		Pod:        pod,
+		PodUid:     podUid,
+		Container:  "container-a",
+		Source:     model.Source{Type: model.LogTypeStdStream},
+		TempBlock:  &model.TempBlock{},
+		PodDeleted: podDeleted,
+	}
+}
+
+func (s *Store) storeTestChunk(chunk *model.Chunk) {
+	s.StoreChunk(chunk.Source, chunk.PodUid, chunk.Container, chunk)
+}
+
+func TestCleanMetricsClearsDeletedPod(t *testing.T) {
+	s := newTestStore()
+	chunk := newTestChunk("pod-a", "uid-a", true)
+	s.storeTestChunk(chunk)
+
+	s.cleanMetrics()
+
+	if !chunk.MetricsCleared {
+		t.Error("expected metrics of the deleted pod to be cleared")
+	}
+}
+
+func TestCleanMetricsKeepsExistingPod(t *testing.T) {
+	s := newTestStore()
+	chunk := newTestChunk("pod-a", "uid-a", false)
+	s.storeTestChunk(chunk)
+
+	s.cleanMetrics()
+
+	if chunk.MetricsCleared {
+		t.Error("expected metrics of the existing pod to be kept")
+	}
+}
+
+func TestCleanMetricsIsIdempotent(t *testing.T) {
+	s := newTestStore()
+	chunk := newTestChunk("pod-a", "uid-a", true)
+	s.storeTestChunk(chunk)
+
+	s.cleanMetrics()
+	s.cleanMetrics()
+
+	if !chunk.MetricsCleared {
+		t.Error("expected the cleared state to hold across repeated sweeps")
+	}
+}
+
+func TestCleanMetricsRearmsWhenPodReappears(t *testing.T) {
+	s := newTestStore()
+	chunk := newTestChunk("pod-a", "uid-a", true)
+	s.storeTestChunk(chunk)
+
+	s.cleanMetrics()
+	if !chunk.MetricsCleared {
+		t.Fatal("expected metrics of the deleted pod to be cleared")
+	}
+
+	// A pod list that briefly missed the pod must not leave the chunk stuck in the cleared state.
+	chunk.PodDeleted = false
+	s.cleanMetrics()
+
+	if chunk.MetricsCleared {
+		t.Error("expected the chunk to be rearmed once the pod reappeared")
+	}
+}
+
+func TestCleanMetricsSparesAliasedLivePod(t *testing.T) {
+	s := newTestStore()
+	// A recreated pod keeps its name but takes a new uid, so both chunks share one metric label set.
+	old := newTestChunk("pod-a", "uid-old", true)
+	recreated := newTestChunk("pod-a", "uid-new", false)
+	s.storeTestChunk(old)
+	s.storeTestChunk(recreated)
+
+	s.cleanMetrics()
+
+	if old.MetricsCleared {
+		t.Error("expected the chunk of the old pod to spare the metrics of its living namesake")
+	}
+	if recreated.MetricsCleared {
+		t.Error("expected metrics of the recreated pod to be kept")
+	}
+}
+
+func TestCleanMetricsClearsDeletedPodOfDistinctName(t *testing.T) {
+	s := newTestStore()
+	gone := newTestChunk("pod-a", "uid-a", true)
+	alive := newTestChunk("pod-b", "uid-b", false)
+	s.storeTestChunk(gone)
+	s.storeTestChunk(alive)
+
+	s.cleanMetrics()
+
+	if !gone.MetricsCleared {
+		t.Error("expected the deleted pod to be cleared when no namesake is alive")
+	}
+	if alive.MetricsCleared {
+		t.Error("expected metrics of the existing pod to be kept")
+	}
+}

--- a/pkg/lobster/store/store.go
+++ b/pkg/lobster/store/store.go
@@ -340,6 +340,7 @@ func (s *Store) markByRetention() {
 func (s *Store) Clean() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
+	s.cleanMetrics()
 	s.cleanChunks()
 	s.cleanDirectoriesWithEmptyBlocks()
 }


### PR DESCRIPTION
### Summary

- Metrics of a container share the lifetime of its logs, so a node that runs short-lived pods keeps a series for every pod that ever ran on it until log retention expires

### Changes

- Add `log_namespace` to the collection metrics and delete by partial match on the log labels, so one label map serves every vector whatever else it declares
- Release the metrics of a chunk as soon as its pod is gone instead of when its logs expire; pod existence rather than a period of silence, so a container that logs only occasionally keeps its series, and a recreated pod of the same name keeps the series its predecessor shared
- Add tests covering the label mismatch, middleware metrics that must survive, and the pod lifecycle around release
