### PR TITLE
feat: add status api to global query

### DIFF
--- a/cmd/lobster-global/main.go
+++ b/cmd/lobster-global/main.go
@@ -49,6 +49,8 @@ func main() {
 
 	router := server.Router()
 
+	router.Path(global.PathStatus).Handler(global.StatusHandler{Querier: querier})
+
 	webHandler := web.WebHandler{Querier: querier}
 	router.Handle("/", webHandler)
 

--- a/pkg/lobster/global/querier.go
+++ b/pkg/lobster/global/querier.go
@@ -38,6 +38,12 @@ var conf config
 type Querier struct {
 	broker.Broker
 	querier.Fetcher
+	remotes []remote
+}
+
+type remote struct {
+	broker.RemoteAddr
+	Registered bool
 }
 
 func init() {
@@ -46,30 +52,52 @@ func init() {
 }
 
 func NewQuerier() *Querier {
+	remotes := parseRemotes()
 	remoteAddrs := []broker.RemoteAddr{}
 	clusters := []string{}
 
-	for _, info := range *conf.LobsterQueries {
-		part := strings.Split(info, "|")
-		splited := strings.Split(part[1], ":")
-
-		if _, err := net.LookupHost(splited[0]); err != nil {
-			glog.Infof("skip host %s.", part[1])
+	for _, r := range remotes {
+		if !r.Registered {
 			continue
 		}
 
-		remoteAddrs = append(remoteAddrs, broker.RemoteAddr{
-			Cluster: part[0],
-			Address: part[1],
-		})
-		clusters = append(clusters, part[0])
+		remoteAddrs = append(remoteAddrs, r.RemoteAddr)
+		clusters = append(clusters, r.Cluster)
 	}
 
 	glog.Infof("actual clusters after host lookup: %s", strings.Join(clusters, ","))
 	return &Querier{
 		Broker:  broker.NewBroker(remoteAddrs),
 		Fetcher: querier.NewFetcher(*conf.FetchTimeout, *conf.FetchResponseHeaderTimeout),
+		remotes: remotes,
 	}
+}
+
+// parseRemotes keeps every configured entry, so that a host missing at startup
+// stays visible instead of disappearing from the configuration.
+func parseRemotes() []remote {
+	remotes := []remote{}
+
+	for _, info := range *conf.LobsterQueries {
+		part := strings.Split(info, "|")
+		splited := strings.Split(part[1], ":")
+		registered := true
+
+		if _, err := net.LookupHost(splited[0]); err != nil {
+			glog.Infof("skip host %s.", part[1])
+			registered = false
+		}
+
+		remotes = append(remotes, remote{
+			RemoteAddr: broker.RemoteAddr{
+				Cluster: part[0],
+				Address: part[1],
+			},
+			Registered: registered,
+		})
+	}
+
+	return remotes
 }
 
 func (q *Querier) GetChunksWithinRange(req query.Request) (chunks []model.Chunk, err error) {

--- a/pkg/lobster/global/status.go
+++ b/pkg/lobster/global/status.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package global
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+)
+
+const (
+	PathStatus = "/status"
+
+	probeTimeout     = 3 * time.Second
+	errNotRegistered = "not registered at startup: host lookup failed"
+)
+
+// probeClient is separate from the clients that carry log requests; a status
+// probe must not wait as long as a log query.
+var probeClient = &http.Client{Timeout: probeTimeout}
+
+// ClusterStatus is one configured lobsterQuery entry and whether it answers.
+type ClusterStatus struct {
+	Cluster   string `json:"cluster"`
+	Address   string `json:"address"`
+	Connected bool   `json:"connected"`
+	Error     string `json:"error,omitempty"`
+}
+
+// Status is the connectivity of every configured lobsterQuery entry.
+type Status struct {
+	Total     int             `json:"total"`
+	Connected int             `json:"connected"`
+	Clusters  []ClusterStatus `json:"clusters"`
+}
+
+// Status probes each configured lobster query and reports whether it answers.
+func (q *Querier) Status() Status {
+	var (
+		wg       sync.WaitGroup
+		clusters = make([]ClusterStatus, len(q.remotes))
+	)
+
+	for i, r := range q.remotes {
+		wg.Add(1)
+
+		go func(i int, r remote) {
+			defer wg.Done()
+			clusters[i] = probe(r)
+		}(i, r)
+	}
+
+	wg.Wait()
+
+	status := Status{Total: len(clusters), Clusters: clusters}
+	for _, cluster := range clusters {
+		if cluster.Connected {
+			status.Connected++
+		}
+	}
+
+	return status
+}
+
+func probe(r remote) ClusterStatus {
+	status := ClusterStatus{Cluster: r.Cluster, Address: r.Address}
+
+	if !r.Registered {
+		status.Error = errNotRegistered
+		return status
+	}
+
+	resp, err := probeClient.Get(fmt.Sprintf("http://%s/health", r.Address))
+	if err != nil {
+		status.Error = err.Error()
+		return status
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	status.Connected = true
+
+	return status
+}
+
+type StatusHandler struct {
+	Querier *Querier
+}
+
+func (h StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	data, err := json.Marshal(h.Querier.Status())
+	if err != nil {
+		glog.Error(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(data); err != nil {
+		glog.Error(err)
+	}
+}

--- a/pkg/lobster/global/status_test.go
+++ b/pkg/lobster/global/status_test.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2024-present NAVER Corp
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package global
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/naver/lobster/pkg/lobster/querier/broker"
+	"github.com/naver/lobster/pkg/lobster/server"
+)
+
+// newFakeQuery serves the health that server.Router() gives every component.
+func newFakeQuery(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(server.Router())
+}
+
+func hostOf(t *testing.T, rawURL string) string {
+	t.Helper()
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return parsed.Host
+}
+
+func newRemote(cluster, address string, registered bool) remote {
+	return remote{
+		RemoteAddr: broker.RemoteAddr{Cluster: cluster, Address: address},
+		Registered: registered,
+	}
+}
+
+func TestStatusConnected(t *testing.T) {
+	alive := newFakeQuery(t)
+	defer alive.Close()
+
+	querier := &Querier{remotes: []remote{newRemote("alive", hostOf(t, alive.URL), true)}}
+	status := querier.Status()
+
+	if status.Total != 1 || status.Connected != 1 {
+		t.Fatalf("expected 1/1 connected, got %d/%d", status.Connected, status.Total)
+	}
+	if !status.Clusters[0].Connected {
+		t.Fatalf("expected connected cluster, got %+v", status.Clusters[0])
+	}
+	if len(status.Clusters[0].Error) > 0 {
+		t.Fatalf("expected no error, got %q", status.Clusters[0].Error)
+	}
+}
+
+func TestStatusUnreachable(t *testing.T) {
+	dead := newFakeQuery(t)
+	address := hostOf(t, dead.URL)
+	dead.Close()
+
+	querier := &Querier{remotes: []remote{newRemote("dead", address, true)}}
+	status := querier.Status()
+
+	if status.Connected != 0 {
+		t.Fatalf("expected 0 connected, got %d", status.Connected)
+	}
+	if len(status.Clusters[0].Error) == 0 {
+		t.Fatal("expected the request error to be reported")
+	}
+	if status.Clusters[0].Error == errNotRegistered {
+		t.Fatal("a registered host must not be reported as unregistered")
+	}
+}
+
+// A host that did not resolve at startup is not queried, so it must be reported
+// as disconnected without a probe telling otherwise.
+func TestStatusNotRegistered(t *testing.T) {
+	alive := newFakeQuery(t)
+	defer alive.Close()
+
+	querier := &Querier{remotes: []remote{newRemote("ghost", hostOf(t, alive.URL), false)}}
+	status := querier.Status()
+
+	if status.Connected != 0 {
+		t.Fatalf("expected 0 connected, got %d", status.Connected)
+	}
+	if status.Clusters[0].Error != errNotRegistered {
+		t.Fatalf("expected %q, got %q", errNotRegistered, status.Clusters[0].Error)
+	}
+}
+
+func TestStatusCounts(t *testing.T) {
+	alive := newFakeQuery(t)
+	defer alive.Close()
+
+	dead := newFakeQuery(t)
+	deadAddress := hostOf(t, dead.URL)
+	dead.Close()
+
+	querier := &Querier{remotes: []remote{
+		newRemote("alive-1", hostOf(t, alive.URL), true),
+		newRemote("alive-2", hostOf(t, alive.URL), true),
+		newRemote("dead", deadAddress, true),
+		newRemote("ghost", "no-such-host:8080", false),
+	}}
+	status := querier.Status()
+
+	if status.Total != 4 || status.Connected != 2 {
+		t.Fatalf("expected 2/4 connected, got %d/%d", status.Connected, status.Total)
+	}
+
+	// The order of the configured entries is kept, so that a caller can match
+	// the cluster it asked about.
+	for i, expected := range []string{"alive-1", "alive-2", "dead", "ghost"} {
+		if status.Clusters[i].Cluster != expected {
+			t.Fatalf("expected cluster %q at %d, got %q", expected, i, status.Clusters[i].Cluster)
+		}
+	}
+}
+
+func TestStatusHandler(t *testing.T) {
+	alive := newFakeQuery(t)
+	defer alive.Close()
+
+	handler := StatusHandler{Querier: &Querier{
+		remotes: []remote{newRemote("alive", hostOf(t, alive.URL), true)},
+	}}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, PathStatus, nil))
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", recorder.Code)
+	}
+	if contentType := recorder.Header().Get("Content-Type"); contentType != "application/json" {
+		t.Fatalf("expected a json content type, got %q", contentType)
+	}
+
+	status := Status{}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.Total != 1 || status.Connected != 1 {
+		t.Fatalf("expected 1/1 connected, got %d/%d", status.Connected, status.Total)
+	}
+
+	// Log contents are served on authenticated routes; this one must not leak
+	// anything but addresses and flags.
+	for _, field := range []string{"contents", "message", "storeAddr"} {
+		if strings.Contains(recorder.Body.String(), field) {
+			t.Fatalf("unexpected field %q in %s", field, recorder.Body.String())
+		}
+	}
+}
+
+func TestStatusHandlerRejectsPost(t *testing.T) {
+	handler := StatusHandler{Querier: &Querier{}}
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, PathStatus, nil))
+
+	if recorder.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", recorder.Code)
+	}
+}


### PR DESCRIPTION
### Summary

- Add status API to report connectivity with configured clusters
- Each entry is probed in parallel with `GET /health`, which every component already serves
- An entry whose host did not resolve at startup is not registered on the broker and is not queried until a restart, so it is reported as disconnected with that reason instead of being probed

`GET /status` reports whether each configured `--global.lobsterQuery` entry answers.

```json
{
  "total": 2,
  "connected": 1,
  "clusters": [
    {"cluster": "a", "address": "lobster-query.a:8080", "connected": true},
    {"cluster": "b", "address": "lobster-query.b:8080", "connected": false, "error": "dial tcp: i/o timeout"}
  ]
}
```